### PR TITLE
Incorporate instruments-systematics plugin

### DIFF
--- a/docs/user/plugins.rst
+++ b/docs/user/plugins.rst
@@ -22,6 +22,13 @@ search PyPI for packages with keywords `taurex <pypi_>`_.
 Using Plugins
 =============
 
+.. note::
+
+    The former ``taurex-instrumentsystematics`` plugin is now integrated into
+    TauREx itself. Its observation loaders are available as the built-in
+    ``spectra_w_offsets`` and ``spectra_instr`` observation types documented in
+    :ref:`userobservation`.
+
 Consult each plugins documentation for installation and usage. Generally TauREx
 searches for entry points in ``taurex.plugins`` and adds each component into the
 correct point in the pipeline

--- a/docs/user/support_data_formats.rst
+++ b/docs/user/support_data_formats.rst
@@ -43,6 +43,8 @@ For observations, the following formats supported
 are:
 
 - Text based 3/4-column data
+- Multi-file text observations with fitted offsets/slopes via ``spectra_w_offsets``
+- Multi-file text observations with optional convolution via ``spectra_instr``
 - ``.pickle`` Outputs from Iraclis_
 
 More formats can be included through :ref:`plugins`

--- a/docs/user/taurex/inputfile.rst
+++ b/docs/user/taurex/inputfile.rst
@@ -103,6 +103,34 @@ However setting ``T`` will throw an error as it doesn't exist anymore::
 This also applies to fitting parameters, profiles provide certain fitting parameters
 and changing the model means that these parameters may not exist anymore.
 
+The same expansion happens in the ``[Observation]`` block. A standard observation
+entry might look like this::
+
+    [Observation]
+    observed_spectrum = /path/to/data.dat
+
+If instead you switch to the integrated multi-instrument loader, the accepted
+keys expand to include per-spectrum systematics controls::
+
+    [Observation]
+    observation = spectra_w_offsets
+    path_spectra = /path/spec_1.dat, /path/spec_2.dat
+    offsets = 0.0, 0.0
+    slopes = 0.0, 0.0
+    error_scale = 1.0, 1.0
+
+That change also adds new fitting parameters such as ``Offset_1``, ``Slope_1``
+and ``EScale_1`` that can be configured in ``[Fitting]``::
+
+    [Fitting]
+    Offset_1:fit = True
+    Slope_1:fit = True
+    EScale_1:fit = True
+
+Using ``observation = spectra_instr`` extends the same pattern with optional
+``broadening_profiles`` entries for wavelength-dependent convolution before the
+final binning stage.
+
 
 Mixins
 ------

--- a/docs/user/taurex/inputfile.rst
+++ b/docs/user/taurex/inputfile.rst
@@ -135,6 +135,34 @@ parameters such as ``m1_T`` whenever profiles are not coupled between regions::
 The same pattern applies to ``model_type = multi_eclipse`` and
 ``model_type = multi_directimage``.
 
+The same expansion happens in the ``[Observation]`` block. A standard observation
+entry might look like this::
+
+    [Observation]
+    observed_spectrum = /path/to/data.dat
+
+If instead you switch to the integrated multi-instrument loader, the accepted
+keys expand to include per-spectrum systematics controls::
+
+    [Observation]
+    observation = spectra_w_offsets
+    path_spectra = /path/spec_1.dat, /path/spec_2.dat
+    offsets = 0.0, 0.0
+    slopes = 0.0, 0.0
+    error_scale = 1.0, 1.0
+
+That change also adds new fitting parameters such as ``Offset_1``, ``Slope_1``
+and ``EScale_1`` that can be configured in ``[Fitting]``::
+
+    [Fitting]
+    Offset_1:fit = True
+    Slope_1:fit = True
+    EScale_1:fit = True
+
+Using ``observation = spectra_instr`` extends the same pattern with optional
+``broadening_profiles`` entries for wavelength-dependent convolution before the
+final binning stage.
+
 
 Mixins
 ------

--- a/docs/user/taurex/observation.rst
+++ b/docs/user/taurex/observation.rst
@@ -18,6 +18,8 @@ Only one of these is required. All accept a string path to a file
 +-------------------------+---------------------------------------------------------------------+
 | ``observed_spectrum``   | ASCII 3/4-column data with format: Wavelength, depth, error, widths |
 +-------------------------+---------------------------------------------------------------------+
+| ``observation``         | Observation class keyword for built-in custom loaders               |
++-------------------------+---------------------------------------------------------------------+
 | ``observed_lightcurve`` | Lightcurve pickle data                                              |
 +-------------------------+---------------------------------------------------------------------+
 | ``iraclis_spectrum``    | Iraclis output pickle data                                          |
@@ -33,6 +35,64 @@ An example of loading an ascii data-set::
 
     [Observation]
     observed_spectrum = /path/to/data.dat
+
+
+Multi-Instrument Systematics
+----------------------------
+
+TauREx also includes built-in observation loaders for combining multiple
+ASCII spectra and fitting simple per-instrument systematics directly in the
+``[Observation]`` block.
+
+Two observation keywords are available:
+
++--------------------------+---------------------------------------------------------------+
+| Keyword                  | Purpose                                                       |
++--------------------------+---------------------------------------------------------------+
+| ``spectra_w_offsets``    | Multiple spectra with per-spectrum offsets, slopes and errors |
++--------------------------+---------------------------------------------------------------+
+| ``spectra_instr``        | Same as above, with optional broadening-profile convolution   |
++--------------------------+---------------------------------------------------------------+
+
+These are selected through the generic ``observation`` field::
+
+    [Observation]
+    observation = spectra_w_offsets
+    path_spectra = /path/spec_1.dat, /path/spec_2.dat
+    offsets = 0.0, 0.0
+    slopes = 0.0, 0.0
+    error_scale = 1.0, 1.0
+
+Each input spectrum should be a 3- or 4-column ASCII file with the usual
+TauREx format: wavelength in microns, observed depth, uncertainty, and
+optionally bin width.
+
+The following fitting parameters are created automatically for each input
+spectrum:
+
+- ``Offset_1``, ``Offset_2``, ...
+- ``Slope_1``, ``Slope_2``, ...
+- ``EScale_1``, ``EScale_2``, ...
+
+This allows a retrieval configuration such as::
+
+    [Observation]
+    observation = spectra_instr
+    path_spectra = /path/spec_1.dat, /path/spec_2.dat
+    offsets = 0.0, 0.0
+    slopes = 0.0, 0.0
+    error_scale = 1.0, 1.0
+    broadening_profiles = /path/profile_1.fits, /path/profile_2.fits
+
+    [Fitting]
+    Offset_1:fit = True
+    Offset_2:fit = True
+    Slope_1:fit = True
+    Slope_2:fit = True
+
+For ``spectra_instr``, the optional ``broadening_profiles`` entries may point
+to STScI-style FITS files containing ``WAVELENGTH`` and ``R`` columns, or to
+two-column text files containing wavelength and resolving power.
 
 
 .. _taurexspectrum:

--- a/src/taurex/binning/__init__.py
+++ b/src/taurex/binning/__init__.py
@@ -1,8 +1,13 @@
 """These modules deal with binning down results from models."""
-from .binner import BinDownType, BinnedSpectrumType, Binner
+
+from .binner import BinDownType
+from .binner import BinnedSpectrumType
+from .binner import Binner
 from .fluxbinner import FluxBinner
+from .fluxbinnerconv import FluxBinnerConv
 from .nativebinner import NativeBinner
 from .simplebinner import SimpleBinner
+
 
 __all__ = [
     "Binner",
@@ -10,5 +15,6 @@ __all__ = [
     "BinnedSpectrumType",
     "SimpleBinner",
     "FluxBinner",
+    "FluxBinnerConv",
     "NativeBinner",
 ]

--- a/src/taurex/binning/fluxbinnerconv.py
+++ b/src/taurex/binning/fluxbinnerconv.py
@@ -1,0 +1,236 @@
+"""Convolution-aware flux binner for multi-instrument observations."""
+
+import typing as t
+
+import numpy as np
+import numpy.typing as npt
+from astropy.io import fits
+
+from taurex import OutputSize
+from taurex.util import compute_bin_edges
+from taurex.util import create_grid_res
+from taurex.util import wnwidth_to_wlwidth
+
+from ..types import ModelOutputType
+from .binner import BinDownType
+from .binner import BinnedSpectrumType
+from .binner import Binner
+from .fluxbinner import FluxBinner
+
+
+class FluxBinnerConv(Binner):
+    """Bin to multiple wavelength grids with optional profile convolution."""
+
+    def __init__(
+        self,
+        wlgrids: t.Sequence[npt.NDArray[np.float64]],
+        wlgrid_widths: t.Sequence[npt.NDArray[np.float64]],
+        broadening_profiles: t.Optional[t.Sequence[str]] = None,
+        broadening_type: str = "stsci_fits",
+        max_wlbroadening: t.Optional[float] = None,
+        factor_cut: int = 5,
+        wlres: float = 15000,
+    ) -> None:
+        super().__init__()
+
+        if len(wlgrids) != len(wlgrid_widths):
+            raise ValueError("wlgrids and wlgrid_widths must have the same length")
+
+        self._wlgrids = [np.asarray(grid, dtype=np.float64) for grid in wlgrids]
+        self._wlgrid_widths = [
+            np.asarray(widths, dtype=np.float64) for widths in wlgrid_widths
+        ]
+        self._broadening_profiles = list(broadening_profiles or [])
+        self._profile_type = broadening_type
+        self._max_wlbroadening = max_wlbroadening
+        self._factor_cut = factor_cut
+        self._wlres = wlres
+
+        self._wlgrid = np.concatenate(self._wlgrids)
+        self._wlgrid_width = np.concatenate(self._wlgrid_widths)
+
+        self.binners: t.List[FluxBinner] = []
+        for grid, widths in zip(self._wlgrids, self._wlgrid_widths):
+            sorter = np.argsort(grid)
+            self.binners.append(FluxBinner(10000.0 / grid[sorter], widths[sorter]))
+
+        self._profiles: t.List[npt.NDArray[np.float64]] = []
+        self._grid_fbs: t.List[FluxBinner] = []
+        if self._profile_type == "stsci_fits" and self._broadening_profiles:
+            if len(self._broadening_profiles) != len(self._wlgrids):
+                raise ValueError(
+                    "broadening_profiles must match the number of wavelength grids"
+                )
+            self._profiles, self._grid_fbs = self.load_stsci_profiles(
+                self._broadening_profiles
+            )
+
+    def load_stsci_profiles(
+        self, files: t.Sequence[str]
+    ) -> t.Tuple[t.List[npt.NDArray[np.float64]], t.List[FluxBinner]]:
+        """Load STScI-style resolution profiles from FITS or text files."""
+
+        profiles: t.List[npt.NDArray[np.float64]] = []
+        grid_fbs: t.List[FluxBinner] = []
+
+        for file_name, wlgrid in zip(files, self._wlgrids):
+            try:
+                with fits.open(file_name) as hdu:
+                    science_data = hdu[1].data
+                wavelength = np.asarray(science_data["WAVELENGTH"], dtype=np.float64)
+                resolution = np.asarray(science_data["R"], dtype=np.float64)
+            except OSError:
+                science_data = np.loadtxt(file_name)
+                wavelength = np.asarray(science_data[:, 0], dtype=np.float64)
+                resolution = np.asarray(science_data[:, 1], dtype=np.float64)
+
+            std = wavelength / resolution / 2.0
+            native_grid = create_grid_res(
+                self._wlres,
+                wlgrid[0] - 10.0 * std[0],
+                wlgrid[-1] + 10.0 * std[-1],
+            )
+            grid_fbs.append(FluxBinner(10000.0 / native_grid[:, 0], native_grid[:, 1]))
+
+            sigma = np.interp(
+                native_grid[:, 0],
+                wavelength,
+                std,
+                left=std[0],
+                right=std[-1],
+            )
+            if self._max_wlbroadening is not None:
+                sigma = np.clip(sigma, a_min=1e-20, a_max=self._max_wlbroadening)
+            else:
+                sigma = np.clip(sigma, a_min=1e-20, a_max=None)
+            profiles.append(sigma)
+
+        return profiles, grid_fbs
+
+    @staticmethod
+    def gaussian(
+        x: npt.NDArray[np.float64], mean: float, std: float
+    ) -> npt.NDArray[np.float64]:
+        """Compute a normalized Gaussian profile."""
+
+        return (
+            1.0
+            / (np.sqrt(2.0 * np.pi) * std)
+            * np.exp(-np.power((x - mean) / std, 2.0) / 2.0)
+        )
+
+    def low_res_convolved(
+        self, binned_output: BinDownType, profile: npt.NDArray[np.float64]
+    ) -> BinDownType:
+        """Convolve a binned spectrum with a wavelength-dependent profile."""
+
+        grid, flux, error, widths = binned_output
+        convolved_flux = np.zeros_like(flux)
+
+        for index, centre in enumerate(grid):
+            std = profile[index]
+            if index != len(grid) - 1:
+                spacing = np.abs(grid[index + 1] - centre)
+            else:
+                spacing = np.abs(centre - grid[index - 1])
+
+            window = max(1, int(self._factor_cut * std / spacing))
+            start = max(0, index - window)
+            stop = min(len(grid), index + window + 1)
+            x = grid[start:stop]
+            weights = self.gaussian(x, centre, std)
+            convolved_flux[start:stop] += flux[index] * weights / np.sum(weights)
+
+        return grid, convolved_flux, error, widths
+
+    def _prepare_input(
+        self,
+        wngrid: npt.NDArray[np.float64],
+        spectrum: npt.NDArray[np.float64],
+        grid_width: t.Optional[npt.NDArray[np.float64]] = None,
+        error: t.Optional[npt.NDArray[np.float64]] = None,
+    ) -> BinDownType:
+        if grid_width is not None:
+            wlgrid_width = wnwidth_to_wlwidth(wngrid, grid_width)[::-1]
+        else:
+            wlgrid_width = None
+
+        wlerror = error[::-1] if error is not None else None
+        return 10000.0 / wngrid[::-1], spectrum[::-1], wlerror, wlgrid_width
+
+    def bindown(
+        self,
+        wngrid: npt.NDArray[np.float64],
+        spectrum: npt.NDArray[np.float64],
+        grid_width: t.Optional[npt.NDArray[np.float64]] = None,
+        error: t.Optional[npt.NDArray[np.float64]] = None,
+    ) -> BinDownType:
+        """Bind a native model spectrum to the configured instrument grids."""
+
+        wlgrid, flux, wlerror, wlwidth = self._prepare_input(
+            wngrid, spectrum, grid_width=grid_width, error=error
+        )
+        prepared: BinDownType = (wlgrid, flux, wlerror, wlwidth)
+
+        wlgrids: t.List[npt.NDArray[np.float64]] = []
+        spectra: t.List[npt.NDArray[np.float64]] = []
+        errors: t.List[npt.NDArray[np.float64]] = []
+        widths: t.List[npt.NDArray[np.float64]] = []
+
+        for index, binner in enumerate(self.binners):
+            working_output = prepared
+            if self._profile_type == "stsci_fits" and self._profiles:
+                working_output = self._grid_fbs[index].bindown(
+                    10000.0 / prepared[0],
+                    prepared[1],
+                    grid_width=prepared[3],
+                    error=prepared[2],
+                )
+                working_output = (
+                    10000.0 / working_output[0][::-1],
+                    working_output[1][::-1],
+                    None if working_output[2] is None else working_output[2][::-1],
+                    None if working_output[3] is None else working_output[3][::-1],
+                )
+                working_output = self.low_res_convolved(
+                    working_output, self._profiles[index]
+                )
+                working_output = (
+                    10000.0 / working_output[0][::-1],
+                    working_output[1][::-1],
+                    None if working_output[2] is None else working_output[2][::-1],
+                    None if working_output[3] is None else working_output[3][::-1],
+                )
+
+            binned_output = binner.bindown(
+                working_output[0],
+                working_output[1],
+                grid_width=working_output[3],
+                error=working_output[2],
+            )
+            wlgrids.append(10000.0 / binned_output[0])
+            spectra.append(binned_output[1])
+            widths.append(wnwidth_to_wlwidth(binned_output[0], binned_output[3]))
+            if binned_output[2] is not None:
+                errors.append(binned_output[2])
+
+        merged_wlgrid = np.concatenate(wlgrids)
+        merged_spectrum = np.concatenate(spectra)
+        merged_error = np.concatenate(errors) if errors else None
+        merged_widths = np.concatenate(widths)
+
+        return merged_wlgrid, merged_spectrum, merged_error, merged_widths
+
+    def generate_spectrum_output(
+        self,
+        model_output: ModelOutputType,
+        output_size: t.Optional[OutputSize] = OutputSize.heavy,
+    ) -> BinnedSpectrumType:
+        """Generate a TauREx-style spectrum output dictionary."""
+
+        output = super().generate_spectrum_output(model_output, output_size=output_size)
+        output["binned_wngrid"] = 10000.0 / self._wlgrid
+        output["binned_wlgrid"] = self._wlgrid
+        output["binned_wnwidth"] = compute_bin_edges(output["binned_wngrid"])[-1]
+        output["binned_wlwidth"] = self._wlgrid_width
+        return output

--- a/src/taurex/data/spectrum/__init__.py
+++ b/src/taurex/data/spectrum/__init__.py
@@ -2,7 +2,17 @@
 
 from .array import ArraySpectrum
 from .observed import ObservedSpectrum
+from .offsetspectrum import OffsetSpectra
+from .offsetspectrum import OffsetSpectraCont
 from .spectrum import BaseSpectrum
 from .taurex import TaurexSpectrum
 
-__all__ = ["BaseSpectrum", "ObservedSpectrum", "ArraySpectrum", "TaurexSpectrum"]
+
+__all__ = [
+    "BaseSpectrum",
+    "ObservedSpectrum",
+    "ArraySpectrum",
+    "OffsetSpectra",
+    "OffsetSpectraCont",
+    "TaurexSpectrum",
+]

--- a/src/taurex/data/spectrum/offsetspectrum.py
+++ b/src/taurex/data/spectrum/offsetspectrum.py
@@ -1,0 +1,282 @@
+"""Observed spectra with per-instrument systematic corrections."""
+
+import copy
+import typing as t
+
+import numpy as np
+import numpy.typing as npt
+
+from taurex.binning import FluxBinnerConv
+from taurex.util import compute_bin_edges
+from taurex.util import wnwidth_to_wlwidth
+
+from .spectrum import BaseSpectrum
+
+
+class _OffsetSpectrumBase(BaseSpectrum):
+    """Shared implementation for multi-spectrum observations."""
+
+    def __init__(
+        self,
+        path_spectra: t.Optional[t.Sequence[str]] = None,
+        offsets: t.Optional[t.Sequence[float]] = None,
+        slopes: t.Optional[t.Sequence[float]] = None,
+        error_scale: t.Optional[t.Sequence[float]] = None,
+        slope_type: t.Optional[str] = "linear",
+    ) -> None:
+        super().__init__(self.__class__.__name__)
+
+        self.path_spectra = list(path_spectra or [])
+        self.slope_type = slope_type
+        self.offsets = self._normalize_parameter(offsets, 0.0, "offsets")
+        self.slopes = self._normalize_parameter(slopes, 0.0, "slopes")
+        self.escale = self._normalize_parameter(error_scale, 1.0, "error_scale")
+
+        self._raw = [self._load_spectrum(path) for path in self.path_spectra]
+        self._raw = [self._sort_spectrum(spectrum) for spectrum in self._raw]
+
+        self._raw_bin_edges: t.List[npt.NDArray[np.float64]] = []
+        self._raw_bin_widths: t.List[npt.NDArray[np.float64]] = []
+        self._raw_wnwidths: t.List[npt.NDArray[np.float64]] = []
+        self._bin_edges = np.array([], dtype=np.float64)
+        self._wnwidths = np.array([], dtype=np.float64)
+
+        self._process_spectra()
+        self._obs_spectrum = self._combine_raw_spectra()
+        self.generate_offset_fitting_params()
+
+    def _normalize_parameter(
+        self,
+        values: t.Optional[t.Sequence[float]],
+        default: float,
+        parameter_name: str,
+    ) -> t.List[float]:
+        count = len(self.path_spectra)
+        if values is None:
+            return [default] * count
+
+        normalized = list(values)
+        if len(normalized) == 0:
+            return [default] * count
+        if len(normalized) != count:
+            raise ValueError(
+                f"{parameter_name} must have the same length as path_spectra"
+            )
+        return normalized
+
+    @staticmethod
+    def _load_spectrum(path: str) -> npt.NDArray[np.float64]:
+        data = np.loadtxt(path)
+        if data.ndim == 1:
+            data = np.array([data], dtype=np.float64)
+        if data.ndim != 2 or data.shape[1] not in (3, 4):
+            raise ValueError("spectra must be a 2D array with 3 or 4 columns")
+        return np.asarray(data, dtype=np.float64)
+
+    @staticmethod
+    def _sort_spectrum(spectrum: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+        sorter = np.argsort(spectrum[:, 0])
+        return spectrum[sorter, :]
+
+    def _process_spectra(self) -> None:
+        if not self._raw:
+            return
+
+        for spectrum in self._raw:
+            if spectrum.shape[1] == 3:
+                bin_edges, bin_widths = compute_bin_edges(spectrum[:, 0])
+            else:
+                bin_widths = spectrum[:, 3]
+                obs_wl = spectrum[:, 0]
+                bin_edges = np.empty(bin_widths.size * 2, dtype=np.float64)
+                bin_edges[0::2] = obs_wl - bin_widths / 2.0
+                bin_edges[1::2] = obs_wl + bin_widths / 2.0
+
+            self._raw_bin_edges.append(bin_edges)
+            self._raw_bin_widths.append(bin_widths)
+            self._raw_wnwidths.append(wnwidth_to_wlwidth(spectrum[:, 0], bin_widths))
+
+        self._bin_edges = np.concatenate(self._raw_bin_edges)
+        self._wnwidths = np.concatenate(self._raw_wnwidths)
+
+    def _combine_raw_spectra(self) -> npt.NDArray[np.float64]:
+        if not self._raw:
+            return np.empty((0, 4), dtype=np.float64)
+
+        normalized = [
+            np.column_stack([spectrum[:, :3], widths])
+            for spectrum, widths in zip(self._raw, self._raw_bin_widths)
+        ]
+        return np.vstack(normalized)
+
+    @property
+    def rawData(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Data read from file."""
+        return self._obs_spectrum
+
+    @property
+    def wavelengthGrid(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Wavelength grid in microns."""
+        return self.rawData[:, 0]
+
+    @property
+    def binEdges(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Bin edges in wavenumber space."""
+        return 10000.0 / self._bin_edges
+
+    @property
+    def binWidths(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Bin widths in wavenumber space."""
+        return self._wnwidths
+
+    @property
+    def spectrum(self) -> npt.NDArray[np.float64]:
+        """Spectrum with per-instrument systematic corrections applied."""
+
+        fluxes = []
+        for spectrum, offset, slope in zip(self._raw, self.offsets, self.slopes):
+            corrected = copy.deepcopy(spectrum[:, 1])
+            wavelengths = spectrum[:, 0]
+
+            if self.slope_type in ("linear", None):
+                corrected = (
+                    corrected + offset + slope * (wavelengths - np.mean(wavelengths))
+                )
+            elif self.slope_type == "log":
+                corrected = (
+                    corrected
+                    + offset
+                    + slope * np.power(10.0, wavelengths - np.mean(wavelengths))
+                )
+            else:
+                raise ValueError(f"Unsupported slope_type {self.slope_type}")
+
+            fluxes.append(corrected)
+
+        return np.concatenate(fluxes) if fluxes else np.array([], dtype=np.float64)
+
+    @property
+    def errorBar(self) -> npt.NDArray[np.float64]:  # noqa: N802
+        """Error bars with per-instrument scaling applied."""
+
+        errors = [
+            scale * spectrum[:, 2] for spectrum, scale in zip(self._raw, self.escale)
+        ]
+        return np.concatenate(errors) if errors else np.array([], dtype=np.float64)
+
+    def generate_offset_fitting_params(self) -> None:
+        """Create fittable parameters for each input spectrum."""
+
+        bounds = (-0.001, 0.001)
+        for index in range(len(self.offsets)):
+            point_num = index + 1
+
+            def read_offset(self, index=index):
+                return self.offsets[index]
+
+            def write_offset(self, value, index=index):
+                self.offsets[index] = value
+
+            self.add_fittable_param(
+                f"Offset_{point_num}",
+                f"$Offset_{point_num}$",
+                read_offset,
+                write_offset,
+                "linear",
+                False,
+                bounds,
+            )
+
+            def read_escale(self, index=index):
+                return self.escale[index]
+
+            def write_escale(self, value, index=index):
+                self.escale[index] = value
+
+            self.add_fittable_param(
+                f"EScale_{point_num}",
+                f"$Escale_{point_num}$",
+                read_escale,
+                write_escale,
+                "linear",
+                False,
+                bounds,
+            )
+
+            def read_slope(self, index=index):
+                return self.slopes[index]
+
+            def write_slope(self, value, index=index):
+                self.slopes[index] = value
+
+            self.add_fittable_param(
+                f"Slope_{point_num}",
+                f"$Slope_{point_num}$",
+                read_slope,
+                write_slope,
+                "linear",
+                False,
+                bounds,
+            )
+
+
+class OffsetSpectra(_OffsetSpectrumBase):
+    """Multiple observed spectra with offset, slope, and error-scale parameters."""
+
+    @classmethod
+    def input_keywords(cls) -> t.Tuple[str, ...]:
+        """Input keywords for the basic multi-spectrum implementation."""
+
+        return ("spectra_w_offsets", "observation_w_offsets")
+
+
+class OffsetSpectraCont(_OffsetSpectrumBase):
+    """Multiple observed spectra with optional instrument broadening."""
+
+    def __init__(
+        self,
+        path_spectra: t.Optional[t.Sequence[str]] = None,
+        offsets: t.Optional[t.Sequence[float]] = None,
+        slopes: t.Optional[t.Sequence[float]] = None,
+        error_scale: t.Optional[t.Sequence[float]] = None,
+        slope_type: t.Optional[str] = "linear",
+        broadening_type: str = "stsci_fits",
+        broadening_profiles: t.Optional[t.Sequence[str]] = None,
+        wlshift: float = 0.0,
+        max_wlbroadening: float = 0.1,
+        factor_cut: int = 5,
+        wlres: float = 15000,
+    ) -> None:
+        self._wlshift = wlshift
+        self._broadening_profiles = list(broadening_profiles or [])
+        self._profile_type = broadening_type
+        self._max_wlbroadening = max_wlbroadening
+        self._factor_cut = factor_cut
+        self._wlres = wlres
+
+        super().__init__(
+            path_spectra=path_spectra,
+            offsets=offsets,
+            slopes=slopes,
+            error_scale=error_scale,
+            slope_type=slope_type,
+        )
+
+    def create_binner(self) -> FluxBinnerConv:
+        """Create a multi-grid binner for the instrument spectra."""
+
+        return FluxBinnerConv(
+            wlgrids=[spectrum[:, 0] for spectrum in self._raw],
+            wlgrid_widths=self._raw_bin_widths,
+            broadening_profiles=self._broadening_profiles,
+            broadening_type=self._profile_type,
+            max_wlbroadening=self._max_wlbroadening,
+            factor_cut=self._factor_cut,
+            wlres=self._wlres,
+        )
+
+    @classmethod
+    def input_keywords(cls) -> t.Tuple[str, ...]:
+        """Input keywords for the instrument-systematics implementation."""
+
+        return ("spectra_instr", "observation_instr")

--- a/src/taurex/spectrum.py
+++ b/src/taurex/spectrum.py
@@ -1,8 +1,12 @@
-from taurex.data.spectrum.spectrum import BaseSpectrum
-from taurex.data.spectrum.observed import ObservedSpectrum
 from taurex.data.spectrum.array import ArraySpectrum
 from taurex.data.spectrum.iraclis import IraclisSpectrum
+from taurex.data.spectrum.observed import ObservedSpectrum
+from taurex.data.spectrum.offsetspectrum import OffsetSpectra
+from taurex.data.spectrum.offsetspectrum import OffsetSpectraCont
+from taurex.data.spectrum.spectrum import BaseSpectrum
+
+
 try:
     from taurex.data.spectrum.lightcurve import ObservedLightCurve
 except ImportError:
-    print('pylightcurve not install. Ignoring')
+    print("pylightcurve not install. Ignoring")

--- a/tests/spectrum/test_spectrum.py
+++ b/tests/spectrum/test_spectrum.py
@@ -7,9 +7,12 @@ from unittest.mock import patch
 
 import numpy as np
 
+from taurex.binning import FluxBinnerConv
 from taurex.data.spectrum.observed import ObservedSpectrum
+from taurex.data.spectrum.offsetspectrum import OffsetSpectraCont
 from taurex.data.spectrum.spectrum import BaseSpectrum
 from taurex.data.spectrum.taurex import TaurexSpectrum
+
 
 test_data_with_bin = np.array(
     [
@@ -171,7 +174,8 @@ class TaurexSpectrumTest(unittest.TestCase):
         import os
 
         from taurex.output.hdf5 import HDF5Output
-        from taurex.util import compute_bin_edges, wnwidth_to_wlwidth
+        from taurex.util import compute_bin_edges
+        from taurex.util import wnwidth_to_wlwidth
 
         file_path = os.path.join(self.test_dir, "test.hdf5")
 
@@ -206,3 +210,52 @@ class TaurexSpectrumTest(unittest.TestCase):
         np.testing.assert_array_equal(ts.wavelengthGrid, wlgrid)
         np.testing.assert_array_equal(ts.errorBar, error)
         np.testing.assert_array_almost_equal(ts.binWidths, wnwidth)
+
+
+class OffsetSpectraContTest(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _create_spectrum_file(self, filename, data):
+        import os
+
+        file_path = os.path.join(self.test_dir, filename)
+        np.savetxt(file_path, data)
+        return file_path
+
+    def test_multi_spectrum_systematics(self):
+        first = np.array(
+            [
+                [1.0, 10.0, 0.1, 0.05],
+                [1.2, 12.0, 0.2, 0.05],
+            ]
+        )
+        second = np.array(
+            [
+                [2.0, 20.0, 0.3, 0.10],
+                [2.3, 23.0, 0.4, 0.10],
+            ]
+        )
+
+        first_file = self._create_spectrum_file("first.dat", first)
+        second_file = self._create_spectrum_file("second.dat", second)
+
+        spectrum = OffsetSpectraCont(
+            path_spectra=[first_file, second_file],
+            offsets=[0.5, -0.5],
+            slopes=[1.0, -1.0],
+            error_scale=[2.0, 0.5],
+            broadening_type="none",
+        )
+
+        expected_flux = np.array([10.4, 12.6, 19.65, 22.35])
+        expected_error = np.array([0.2, 0.4, 0.15, 0.2])
+
+        np.testing.assert_allclose(spectrum.spectrum, expected_flux)
+        np.testing.assert_allclose(spectrum.errorBar, expected_error)
+        self.assertEqual(spectrum["Offset_1"], 0.5)
+        self.assertEqual(spectrum["Slope_2"], -1.0)
+        self.assertIsInstance(spectrum.create_binner(), FluxBinnerConv)


### PR DESCRIPTION
This PR integrates the [`instrument-systematics`](https://github.com/groningen-exoatmospheres/taurex-instrumentsystematics) plugin functionality directly into TauREx core.

As discussed, before merging to main, we should 
- [ ] test the results carefully from a scientific and a computational point of view (maybe even adding more integration tests?)
- [ ] identify any new developments related to the `instruments-systematics` plugins that make sense to include in this PR

## What changed

- Added `OffsetSpectra` and `OffsetSpectraCont` as built-in observation loaders
- Added `FluxBinnerConv`, a convolution-aware flux binner for multi-instrument wavelength grids
- Registered the new observation and binning classes in the public package exports
- Documented the new observation keywords and input-file usage
- Added spectrum tests covering multi-spectrum offsets/slopes/error scaling and binner creation

## New observation modes

This introduces two built-in observation keywords:

- `spectra_w_offsets`
  - combine multiple ASCII spectra
  - support per-spectrum `offsets`, `slopes`, and `error_scale`
  - automatically expose fitting parameters like `Offset_1`, `Slope_1`, `EScale_1`

- `spectra_instr`
  - same multi-spectrum systematics support as above
  - adds optional convolution using STScI-style broadening profiles before final binning

## Implementation details

- Multi-spectrum observations accept standard TauREx 3/4-column ASCII input files
- Per-spectrum corrections are applied directly in the observation object
- `spectra_instr` creates a `FluxBinnerConv` instance that can:
  - bin to multiple wavelength grids
  - optionally load broadening profiles from FITS or 2-column text files
  - perform wavelength-dependent Gaussian convolution before binning

## Differences from the original plugin

This PR adds some modifications to the original `groningen-exoatmospheres/taurex-instrumentsystematics`. The core numerical behavior is largely preserved, but there are a few implementation changes that are worth highlighting:

- Parameter handling is stricter. In the plugin, some mismatched parameter arrays were silently replaced with defaults:

```py
# before
if len(self.slopes) != len(self.path_spectra):
    self.slopes = [0.0] * len(self.path_spectra)

if len(self.escale) != len(self.path_spectra):
    self.escale = [1.0] * len(self.path_spectra)
```

In the integrated version, `offsets`, `slopes`, and `error_scale` all go through a common normalization path, and inconsistent lengths now fail explicitly:

```py
# after
self.offsets = self._normalize_parameter(offsets, 0.0, "offsets")
self.slopes = self._normalize_parameter(slopes, 0.0, "slopes")
self.escale = self._normalize_parameter(error_scale, 1.0, "error_scale")
```

```py
if len(normalized) != count:
    raise ValueError(
        f"{parameter_name} must have the same length as path_spectra"
    )
```

- The offset-only observation path no longer follows the plugin’s merge-then-global-sort behavior. The original plugin merged all spectra and then reordered the final combined result:

```py
# before
self.sort = self._obs_spectrum[:, 0].argsort(axis=0)[::-1]
...
X = X[self.sort]
return X
```

The integrated implementation sorts each spectrum individually and then concatenates them:

```py
# after
self._raw = [self._sort_spectrum(spectrum) for spectrum in self._raw]
...
return np.vstack(normalized)
```

This is the main user-visible computational difference relative to the plugin, since it can change the final ordering semantics of `spectra_w_offsets` even though the offset/slope/error corrections themselves are conceptually the same.

- The convolution-aware binner has been simplified internally. The plugin had separate 1D and 2D bindown paths, while this PR routes everything through a shared preparation/bindown flow. 

- For broadening-profile this PR version checks wavelength-grid and profile consistency before loading and applying STScI-style profiles, which makes failure modes clearer for invalid instrument configurations.

There are other minor changes to avoid a bit of duplication with the core of TauREx, in particular for binning.

## Documentation

The user docs now describe:
- the new observation keywords in `[Observation]`
- the extra dynamic input keys (`path_spectra`, `offsets`, `slopes`, `error_scale`, `broadening_profiles`)
- the new automatically generated fitting parameters
- that the former `taurex-instrumentsystematics` plugin functionality is now built in