### PR TITLE
 Add Astropy Quantity support at physical input boundaries

### DIFF
--- a/src/taurex/data/planet.py
+++ b/src/taurex/data/planet.py
@@ -6,6 +6,7 @@ from warnings import warn
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.constants import AU
 from taurex.constants import MJUP
@@ -15,6 +16,7 @@ from taurex.log import Logger
 from taurex.output import OutputGroup
 from taurex.output.writeable import Writeable
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 from taurex.util import conversion_factor
 
 from .citation import Citable
@@ -33,10 +35,10 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
 
     def __init__(
         self,
-        planet_mass: t.Optional[float] = 1.0,
-        planet_radius: t.Optional[float] = 1.0,
-        planet_sma: t.Optional[float] = None,
-        planet_distance: t.Optional[float] = 1.0,
+        planet_mass: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        planet_radius: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        planet_sma: t.Optional[t.Union[float, u.Quantity]] = None,
+        planet_distance: t.Optional[t.Union[float, u.Quantity]] = 1.0,
         impact_param: t.Optional[float] = 0.5,
         orbital_period: t.Optional[float] = 2.0,
         albedo: t.Optional[float] = 0.3,
@@ -46,17 +48,17 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
 
         Parameters
         ----------
-        planet_mass: float, optional
-            mass in terms of Jupiter mass of the planet
+        planet_mass: float or astropy.units.Quantity, optional
+            Mass in Jupiter masses when unitless.
 
-        planet_radius: float, optional
-            radius in terms of Jupiter radii of the planet
+        planet_radius: float or astropy.units.Quantity, optional
+            Radius in Jupiter radii when unitless.
 
-        planet_sma: float, optional
-            Semi-major axis in AU
+        planet_sma: float or astropy.units.Quantity, optional
+            Semi-major axis in AU when unitless.
 
-        planet_distance: float, optional
-            Semi-major axis in AU (Deprecated)
+        planet_distance: float or astropy.units.Quantity, optional
+            Semi-major axis in AU when unitless (deprecated).
 
         impact_param: float, optional
             Impact parameter
@@ -83,47 +85,62 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         self._albedo = albedo
         self._transit_time = transit_time
 
-    def set_planet_radius(self, value: float, unit: t.Optional[str] = "Rjup") -> None:
+    def set_planet_radius(
+        self,
+        value: t.Union[float, u.Quantity],
+        unit: t.Optional[str] = "Rjup",
+    ) -> None:
         """Set planet radius.
 
         Parameters
         ----------
-        value : float
-            Radius value
+        value : float or astropy.units.Quantity
+            Radius value. A plain value is interpreted using ``unit``; a
+            Quantity uses its attached unit.
         unit : str, optional
             Unit of the value, by default "Rjup"
 
         """
-        factor = conversion_factor(unit, "m")
-        self._radius = value * factor
+        default_unit = u.dimensionless_unscaled if unit is None else unit
+        self._radius = convert_to_unit_value(value, u.m, default_unit=default_unit)
 
-    def set_planet_mass(self, value: float, unit="Mjup") -> None:
+    def set_planet_mass(
+        self,
+        value: t.Union[float, u.Quantity],
+        unit: t.Optional[str] = "Mjup",
+    ) -> None:
         """Set planet mass.
 
         Parameters
         ----------
-        value : float
-            Mass value
+        value : float or astropy.units.Quantity
+            Mass value. A plain value is interpreted using ``unit``; a
+            Quantity uses its attached unit.
         unit : str, optional
             Unit of the value, by default "Mjup"
 
         """
-        factor = conversion_factor(unit, "kg")
-        self._mass = value * factor
+        default_unit = u.dimensionless_unscaled if unit is None else unit
+        self._mass = convert_to_unit_value(value, u.kg, default_unit=default_unit)
 
-    def set_planet_semimajoraxis(self, value: float, unit="AU") -> None:
+    def set_planet_semimajoraxis(
+        self,
+        value: t.Union[float, u.Quantity],
+        unit: t.Optional[str] = "AU",
+    ) -> None:
         """Set planet semi major axis.
 
         Parameters
         ----------
-        value : float
-            Semi-major axis value
+        value : float or astropy.units.Quantity
+            Semi-major-axis value. A plain value is interpreted using
+            ``unit``; a Quantity uses its attached unit.
         unit : str, optional
             Unit of the value, by default "AU"
 
         """
-        factor = conversion_factor(unit, "m")
-        self._distance = value * factor
+        default_unit = u.dimensionless_unscaled if unit is None else unit
+        self._distance = convert_to_unit_value(value, u.m, default_unit=default_unit)
 
     def get_planet_radius(self, unit: t.Optional[str] = "Rjup") -> float:
         """Get planet radius in specified unit (default is Rjup).

--- a/src/taurex/data/planet.py
+++ b/src/taurex/data/planet.py
@@ -16,8 +16,8 @@ from taurex.log import Logger
 from taurex.output import OutputGroup
 from taurex.output.writeable import Writeable
 from taurex.types import get_float_dtype
-from taurex.util import convert_to_unit_value
 from taurex.util import conversion_factor
+from taurex.util import convert_to_unit_value
 
 from .citation import Citable
 from .fittable import Fittable

--- a/src/taurex/data/profiles/pressure/arraypressure.py
+++ b/src/taurex/data/profiles/pressure/arraypressure.py
@@ -4,8 +4,11 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.output import OutputGroup
+from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .pressureprofile import PressureProfile
 
@@ -15,18 +18,18 @@ class ArrayPressureProfile(PressureProfile):
 
     def __init__(
         self,
-        array: npt.NDArray[np.float64],
+        array: t.Union[npt.ArrayLike, u.Quantity],
         reverse: t.Optional[bool] = False,
         is_central: t.Optional[bool] = True,
     ):
         """Initialize the pressure profile.
 
-        Array assumes that the pressure is in Pa.
+        Unitless arrays are interpreted as pressure in Pa.
 
         Parameters
         ----------
-        array : npt.NDArray[np.float64]
-            Pressure profile array
+        array : array-like or astropy.units.Quantity
+            Pressure profile in Pa when unitless.
 
         reverse : t.Optional[bool], optional
             Reverse the pressure profile, by default False
@@ -36,14 +39,16 @@ class ArrayPressureProfile(PressureProfile):
             **New in v3.2.0**
 
         """
+        array = convert_to_unit_value(array, u.Pa, default_unit=u.Pa)
+        array = np.asarray(array, dtype=get_float_dtype())
         super().__init__(self.__class__.__name__, array.shape[-1])
 
         self.is_central = is_central
 
         if reverse:
-            self.pressure_array = array[::-1]
+            self.pressure_profile = array[::-1]
         else:
-            self.pressure_array = array
+            self.pressure_profile = array
 
     def compute_pressure_profile(self) -> None:
         """Sets up the pressure profile for the atmosphere model."""

--- a/src/taurex/data/profiles/pressure/pressureprofile.py
+++ b/src/taurex/data/profiles/pressure/pressureprofile.py
@@ -5,6 +5,7 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.citation import Citable
 from taurex.data.fittable import Fittable
@@ -13,6 +14,7 @@ from taurex.log import Logger
 from taurex.output import OutputGroup
 from taurex.output.writeable import Writeable
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 
 class PressureProfile(Fittable, Logger, Writeable, Citable):
@@ -129,8 +131,8 @@ class SimplePressureProfile(PressureProfile):
     def __init__(
         self,
         nlayers: t.Optional[int] = 100,
-        atm_min_pressure: t.Optional[float] = 1e-4,
-        atm_max_pressure: t.Optional[float] = 1e6,
+        atm_min_pressure: t.Optional[t.Union[float, u.Quantity]] = 1e-4,
+        atm_max_pressure: t.Optional[t.Union[float, u.Quantity]] = 1e6,
     ):
         """Initialize pressure profile.
 
@@ -139,17 +141,23 @@ class SimplePressureProfile(PressureProfile):
         nlayers : int
             Number of layers in atmosphere
 
-        atm_min_pressure : float
-            minimum pressure in Pascal (top of atmosphere)
+        atm_min_pressure : float or astropy.units.Quantity
+            Minimum pressure in Pa when unitless (top of atmosphere).
 
-        atm_max_pressure : float
-            maximum pressure in Pascal (surface of planet)
+        atm_max_pressure : float or astropy.units.Quantity
+            Maximum pressure in Pa when unitless (surface of planet).
 
         """
         from warnings import warn
 
         super().__init__("pressure_profile", nlayers)
         self.pressure_profile = None
+        atm_min_pressure = convert_to_unit_value(
+            atm_min_pressure, u.Pa, default_unit=u.Pa
+        )
+        atm_max_pressure = convert_to_unit_value(
+            atm_max_pressure, u.Pa, default_unit=u.Pa
+        )
         if self.WARN:
             warn(
                 "SimplePressureProfile is deprecated. "
@@ -190,16 +198,20 @@ class SimplePressureProfile(PressureProfile):
         return self._atm_min_pressure
 
     @minAtmospherePressure.setter
-    def minAtmospherePressure(self, value: float) -> None:  # noqa: N802
+    def minAtmospherePressure(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set the minimum pressure of atmosphere (top layer) in Pascal.
 
         Parameters
         ----------
-        value : float
-            Minimum pressure in Pascal.
+        value : float or astropy.units.Quantity
+            Minimum pressure in Pa when unitless.
 
         """
-        self._atm_min_pressure = value
+        self._atm_min_pressure = convert_to_unit_value(
+            value, u.Pa, default_unit=u.Pa
+        )
 
     @fitparam(
         param_name="atm_max_pressure",
@@ -213,16 +225,20 @@ class SimplePressureProfile(PressureProfile):
         return self._atm_max_pressure
 
     @maxAtmospherePressure.setter
-    def maxAtmospherePressure(self, value: float):  # noqa: N802
+    def maxAtmospherePressure(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set the maximum pressure of the atmosphere (surface) in Pascal.
 
         Parameters
         ----------
-        value : float
-            Maximum pressure in Pascal.
+        value : float or astropy.units.Quantity
+            Maximum pressure in Pa when unitless.
 
         """
-        self._atm_max_pressure = value
+        self._atm_max_pressure = convert_to_unit_value(
+            value, u.Pa, default_unit=u.Pa
+        )
 
     @property
     def profile(self) -> npt.NDArray[np.float64]:

--- a/src/taurex/data/profiles/pressure/pressureprofile.py
+++ b/src/taurex/data/profiles/pressure/pressureprofile.py
@@ -209,9 +209,7 @@ class SimplePressureProfile(PressureProfile):
             Minimum pressure in Pa when unitless.
 
         """
-        self._atm_min_pressure = convert_to_unit_value(
-            value, u.Pa, default_unit=u.Pa
-        )
+        self._atm_min_pressure = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @fitparam(
         param_name="atm_max_pressure",
@@ -236,9 +234,7 @@ class SimplePressureProfile(PressureProfile):
             Maximum pressure in Pa when unitless.
 
         """
-        self._atm_max_pressure = convert_to_unit_value(
-            value, u.Pa, default_unit=u.Pa
-        )
+        self._atm_max_pressure = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @property
     def profile(self) -> npt.NDArray[np.float64]:

--- a/src/taurex/data/profiles/temperature/__init__.py
+++ b/src/taurex/data/profiles/temperature/__init__.py
@@ -5,6 +5,7 @@ from .guillot import Guillot2010
 from .isothermal import Isothermal
 from .npoint import NPoint
 from .rodgers import Rodgers2000
+from .temparray import TemperatureArray
 from .tprofile import TemperatureProfile
 
 
@@ -15,4 +16,5 @@ __all__ = [
     "NPoint",
     "Rodgers2000",
     "TemperatureFile",
+    "TemperatureArray",
 ]

--- a/src/taurex/data/profiles/temperature/guillot.py
+++ b/src/taurex/data/profiles/temperature/guillot.py
@@ -4,10 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.exceptions import InvalidModelException
 from taurex.output import OutputGroup
+from taurex.util import convert_to_unit_value
 
 from .tprofile import TemperatureProfile
 
@@ -22,19 +24,19 @@ class Guillot2010(TemperatureProfile):
 
     def __init__(
         self,
-        T_irr: t.Optional[float] = 1500,  # noqa: N803
+        T_irr: t.Optional[t.Union[float, u.Quantity]] = 1500,  # noqa: N803
         kappa_irr: t.Optional[float] = 0.01,
         kappa_v1: t.Optional[float] = 0.005,
         kappa_v2: t.Optional[float] = 0.005,
         alpha: t.Optional[float] = 0.5,
-        T_int: t.Optional[float] = 100,  # noqa: N803
+        T_int: t.Optional[t.Union[float, u.Quantity]] = 100,  # noqa: N803
     ):
         """Initialize guillot temperature profile.
 
         Parameters
         ----------
-        T_irr: float
-            planet equilibrium temperature
+        T_irr: float or astropy.units.Quantity
+            Planet equilibrium temperature in K when unitless.
             (Line fixes this but we keep as free parameter)
         kappa_irr: float
             mean infra-red opacity
@@ -44,19 +46,19 @@ class Guillot2010(TemperatureProfile):
             mean optical opacity two
         alpha: float
             ratio between kappa_v1 and kappa_v2 downwards radiation stream
-        T_int: float
-            Internal heating parameter (K)
+        T_int: float or astropy.units.Quantity
+            Internal heating parameter in K when unitless.
 
         """
         super().__init__("Guillot")
 
-        self.T_irr = T_irr
+        self.equilTemperature = T_irr
 
         self.kappa_ir = kappa_irr
         self.kappa_v1 = kappa_v1
         self.kappa_v2 = kappa_v2
         self.alpha = alpha
-        self.T_int = T_int
+        self.internalTemperature = T_int
         self._check_values()
 
     @fitparam(
@@ -70,16 +72,20 @@ class Guillot2010(TemperatureProfile):
         return self.T_irr
 
     @equilTemperature.setter
-    def equilTemperature(self, value: float) -> None:  # noqa: N802
+    def equilTemperature(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set planet equilibrium temperature.
 
         Parameters
         ----------
-        value : float
-            Equilibrium temperature in Kelvin.
+        value : float or astropy.units.Quantity
+            Equilibrium temperature in K when unitless.
 
         """
-        self.T_irr = value
+        self.T_irr = convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     @fitparam(
         param_name="kappa_irr",
@@ -183,16 +189,20 @@ class Guillot2010(TemperatureProfile):
         return self.T_int
 
     @internalTemperature.setter
-    def internalTemperature(self, value: float) -> None:  # noqa: N802
+    def internalTemperature(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set internal temperature parameter.
 
         Parameters
         ----------
-        value : float
-            Internal temperature in Kelvin.
+        value : float or astropy.units.Quantity
+            Internal temperature in K when unitless.
 
         """
-        self.T_int = value
+        self.T_int = convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     def _check_values(self) -> None:
         """Ensures kappa values are valid.

--- a/src/taurex/data/profiles/temperature/guillot.py
+++ b/src/taurex/data/profiles/temperature/guillot.py
@@ -72,9 +72,7 @@ class Guillot2010(TemperatureProfile):
         return self.T_irr
 
     @equilTemperature.setter
-    def equilTemperature(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def equilTemperature(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set planet equilibrium temperature.
 
         Parameters

--- a/src/taurex/data/profiles/temperature/isothermal.py
+++ b/src/taurex/data/profiles/temperature/isothermal.py
@@ -44,9 +44,7 @@ class Isothermal(TemperatureProfile):
         return self._iso_temp
 
     @isoTemperature.setter
-    def isoTemperature(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def isoTemperature(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set the isothermal temperature in K when unitless."""
         self._iso_temp = convert_to_unit_value(
             value, u.K, default_unit=u.K, equivalencies=u.temperature()

--- a/src/taurex/data/profiles/temperature/isothermal.py
+++ b/src/taurex/data/profiles/temperature/isothermal.py
@@ -4,10 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .tprofile import TemperatureProfile
 
@@ -15,17 +17,21 @@ from .tprofile import TemperatureProfile
 class Isothermal(TemperatureProfile):
     """An isothermal temperature-pressure profile."""
 
-    def __init__(self, T: t.Optional[float] = 1500) -> None:  # noqa: N803
+    def __init__(
+        self, T: t.Optional[t.Union[float, u.Quantity]] = 1500  # noqa: N803
+    ) -> None:
         """Initialize isothermal class.
 
         Parameters
         ----------
-        T : float
-            Isothermal Temperature to set in Kelvin
+        T : float or astropy.units.Quantity
+            Isothermal temperature in K when unitless.
         """
         super().__init__("Isothermal")
 
-        self._iso_temp = T
+        self._iso_temp = convert_to_unit_value(
+            T, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     @fitparam(
         param_name="T",
@@ -38,8 +44,13 @@ class Isothermal(TemperatureProfile):
         return self._iso_temp
 
     @isoTemperature.setter
-    def isoTemperature(self, value: float) -> None:  # noqa: N802
-        self._iso_temp = value
+    def isoTemperature(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
+        """Set the isothermal temperature in K when unitless."""
+        self._iso_temp = convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     @property
     def profile(self) -> npt.NDArray[np.float64]:

--- a/src/taurex/data/profiles/temperature/npoint.py
+++ b/src/taurex/data/profiles/temperature/npoint.py
@@ -4,10 +4,13 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.exceptions import InvalidModelException
 from taurex.output import OutputGroup
+from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 from taurex.util import movingaverage
 
 from .tprofile import TemperatureProfile
@@ -39,12 +42,12 @@ class NPoint(TemperatureProfile):
 
     def __init__(
         self,
-        T_surface: t.Optional[float] = 1500.0,  # noqa: N803
-        T_top: t.Optional[float] = 200.0,  # noqa: N803
-        P_surface: t.Optional[float] = None,  # noqa: N803
-        P_top: t.Optional[float] = None,  # noqa: N803
-        temperature_points: t.Optional[npt.ArrayLike] = None,
-        pressure_points: t.Optional[npt.ArrayLike] = None,
+        T_surface: t.Optional[t.Union[float, u.Quantity]] = 1500.0,  # noqa: N803
+        T_top: t.Optional[t.Union[float, u.Quantity]] = 200.0,  # noqa: N803
+        P_surface: t.Optional[t.Union[float, u.Quantity]] = None,  # noqa: N803
+        P_top: t.Optional[t.Union[float, u.Quantity]] = None,  # noqa: N803
+        temperature_points: t.Optional[t.Union[npt.ArrayLike, u.Quantity]] = None,
+        pressure_points: t.Optional[t.Union[npt.ArrayLike, u.Quantity]] = None,
         smoothing_window: t.Optional[int] = 10,
         limit_slope: t.Optional[int] = 9999999,
     ):
@@ -52,27 +55,34 @@ class NPoint(TemperatureProfile):
 
         Parameters
         ----------
-        T_surface : float
-            BOA temperature in Kelvin
-        T_top : float
-            TOA temperature in Kelvin
-        P_surface : float
-            BOA pressure in Pa
-        P_top : float
-            TOA pressure in Pa
-        temperature_points : array-like
-            Temperature points
-        pressure_points : array-like
-            Pressure points
+        T_surface : float or astropy.units.Quantity
+            BOA temperature in K when unitless.
+        T_top : float or astropy.units.Quantity
+            TOA temperature in K when unitless.
+        P_surface : float or astropy.units.Quantity
+            BOA pressure in Pa when unitless.
+        P_top : float or astropy.units.Quantity
+            TOA pressure in Pa when unitless.
+        temperature_points : array-like or astropy.units.Quantity
+            Temperature points in K when unitless.
+        pressure_points : array-like or astropy.units.Quantity
+            Pressure points in Pa when unitless.
         smoothing_window : int
             Smoothing window
         limit_slope : int
             Gradient limit to be considered valid
         """
-        temperature_points = (
-            temperature_points if temperature_points is not None else []
+        temperature_points = convert_to_unit_value(
+            temperature_points if temperature_points is not None else [],
+            u.K,
+            default_unit=u.K,
+            equivalencies=u.temperature(),
         )
-        pressure_points = pressure_points if pressure_points is not None else []
+        pressure_points = convert_to_unit_value(
+            pressure_points if pressure_points is not None else [],
+            u.Pa,
+            default_unit=u.Pa,
+        )
 
         super().__init__(f"{len(temperature_points) + 2}Point")
 
@@ -91,12 +101,16 @@ class NPoint(TemperatureProfile):
         self.info("Npoint temeprature profile is initialized")
         self.debug("Passed temeprature points %s", temperature_points)
         self.debug("Passed pressure points %s", pressure_points)
-        self._t_points = temperature_points
-        self._p_points = pressure_points
-        self._T_surface = T_surface
-        self._T_top = T_top
-        self._P_surface = P_surface
-        self._P_top = P_top
+        self._t_points = np.asarray(temperature_points, dtype=get_float_dtype())
+        self._p_points = np.asarray(pressure_points, dtype=get_float_dtype())
+        self.temperatureSurface = T_surface
+        self.temperatureTop = T_top
+        self._P_surface = None
+        self._P_top = None
+        if P_surface is not None:
+            self.pressureSurface = P_surface
+        if P_top is not None:
+            self.pressureTop = P_top
         self._smooth_window = smoothing_window
         self._limit_slope = limit_slope
         self.generate_pressure_fitting_params()
@@ -113,7 +127,9 @@ class NPoint(TemperatureProfile):
         return self._T_surface
 
     @temperatureSurface.setter
-    def temperatureSurface(self, value: float) -> None:  # noqa: N802
+    def temperatureSurface(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Temperature at planet surface in Kelvin.
 
         Parameters
@@ -122,7 +138,9 @@ class NPoint(TemperatureProfile):
             Surface temperature in Kelvin.
 
         """
-        self._T_surface = value
+        self._T_surface = convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     @fitparam(
         param_name="T_top",
@@ -135,7 +153,9 @@ class NPoint(TemperatureProfile):
         return self._T_top
 
     @temperatureTop.setter
-    def temperatureTop(self, value: float) -> None:  # noqa: N802
+    def temperatureTop(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Temperature at top of atmosphere in Kelvin.
 
         Parameters
@@ -144,7 +164,9 @@ class NPoint(TemperatureProfile):
             Top temperature in Kelvin.
 
         """
-        self._T_top = value
+        self._T_top = convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
 
     @fitparam(
         param_name="P_surface",
@@ -158,7 +180,9 @@ class NPoint(TemperatureProfile):
         return self._P_surface
 
     @pressureSurface.setter
-    def pressureSurface(self, value: float) -> None:  # noqa: N802
+    def pressureSurface(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Pressure at planet surface in Pa.
 
         Parameters
@@ -167,7 +191,7 @@ class NPoint(TemperatureProfile):
             Surface pressure in Pa.
 
         """
-        self._P_surface = value
+        self._P_surface = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @fitparam(
         param_name="P_top",
@@ -181,7 +205,9 @@ class NPoint(TemperatureProfile):
         return self._P_top
 
     @pressureTop.setter
-    def pressureTop(self, value: float) -> None:  # noqa: N802
+    def pressureTop(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Pressure at top of atmosphere in Pa.
 
         Parameters
@@ -190,7 +216,7 @@ class NPoint(TemperatureProfile):
             Top pressure in Pa.
 
         """
-        self._P_top = value
+        self._P_top = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     def generate_pressure_fitting_params(self) -> None:
         """Generates the fitting parameters for the pressure points.
@@ -209,7 +235,9 @@ class NPoint(TemperatureProfile):
                 return self._p_points[idx]
 
             def write_point(self, value, idx=idx):
-                self._p_points[idx] = value
+                self._p_points[idx] = convert_to_unit_value(
+                    value, u.Pa, default_unit=u.Pa
+                )
 
             read_point.__doc__ = f"Pressure point {point_num} in Pa"
 
@@ -244,7 +272,9 @@ class NPoint(TemperatureProfile):
                 return self._t_points[idx]
 
             def write_point(self, value, idx=idx):
-                self._t_points[idx] = value
+                self._t_points[idx] = convert_to_unit_value(
+                    value, u.K, default_unit=u.K, equivalencies=u.temperature()
+                )
 
             read_point.__doc__ = f"Temperature point {point_num} in K"
 

--- a/src/taurex/data/profiles/temperature/npoint.py
+++ b/src/taurex/data/profiles/temperature/npoint.py
@@ -153,9 +153,7 @@ class NPoint(TemperatureProfile):
         return self._T_top
 
     @temperatureTop.setter
-    def temperatureTop(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def temperatureTop(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Temperature at top of atmosphere in Kelvin.
 
         Parameters
@@ -180,9 +178,7 @@ class NPoint(TemperatureProfile):
         return self._P_surface
 
     @pressureSurface.setter
-    def pressureSurface(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def pressureSurface(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Pressure at planet surface in Pa.
 
         Parameters
@@ -205,9 +201,7 @@ class NPoint(TemperatureProfile):
         return self._P_top
 
     @pressureTop.setter
-    def pressureTop(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def pressureTop(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Pressure at top of atmosphere in Pa.
 
         Parameters

--- a/src/taurex/data/profiles/temperature/rodgers.py
+++ b/src/taurex/data/profiles/temperature/rodgers.py
@@ -4,9 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.output import OutputGroup
+from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .tprofile import TemperatureProfile
 
@@ -23,7 +26,7 @@ class Rodgers2000(TemperatureProfile):
 
     def __init__(
         self,
-        temperature_layers: t.Optional[npt.ArrayLike] = None,
+        temperature_layers: t.Optional[t.Union[npt.ArrayLike, u.Quantity]] = None,
         correlation_length: t.Optional[float] = 5.0,
         covariance_matrix: t.Optional[npt.NDArray[np.float64]] = None,
     ) -> None:
@@ -31,8 +34,8 @@ class Rodgers2000(TemperatureProfile):
 
         Parameters
         ----------
-        temperature_layers : :obj:`list`
-            Temperature in Kelvin per layer of pressure
+        temperature_layers : array-like or astropy.units.Quantity
+            Temperature in K per pressure layer when unitless.
 
         correlation_length : float
             In scaleheights, Line et al. 2013 sets this to 7, Irwin et al
@@ -47,7 +50,15 @@ class Rodgers2000(TemperatureProfile):
 
         self._tp_corr_length = correlation_length
         self._covariance = covariance_matrix
-        self.temperature_layers = np.array(temperature_layers)
+        temperature_layers = convert_to_unit_value(
+            temperature_layers,
+            u.K,
+            default_unit=u.K,
+            equivalencies=u.temperature(),
+        )
+        self.temperature_layers = np.asarray(
+            temperature_layers, dtype=get_float_dtype()
+        )
         self.generate_temperature_fitting_params()
 
     def gen_covariance(self) -> npt.NDArray[np.float64]:
@@ -125,7 +136,9 @@ class Rodgers2000(TemperatureProfile):
                 return self.temperature_layers[idx]
 
             def write_point(self, value, idx=idx):
-                self.temperature_layers[idx] = value
+                self.temperature_layers[idx] = convert_to_unit_value(
+                    value, u.K, default_unit=u.K, equivalencies=u.temperature()
+                )
 
             read_point.__doc__ = f"Temperature at layer {point_num} in Kelvin"
 

--- a/src/taurex/data/profiles/temperature/temparray.py
+++ b/src/taurex/data/profiles/temperature/temparray.py
@@ -44,9 +44,7 @@ class TemperatureArray(TemperatureProfile):
         if reverse:
             self._tp_profile = self._tp_profile[::-1]
         if p_points is not None:
-            p_points = convert_to_unit_value(
-                p_points, u.Pa, default_unit=u.Pa
-            )
+            p_points = convert_to_unit_value(p_points, u.Pa, default_unit=u.Pa)
             self._p_profile = np.asarray(p_points, dtype=get_float_dtype())
             if reverse:
                 self._p_profile = self._p_profile[::-1]

--- a/src/taurex/data/profiles/temperature/temparray.py
+++ b/src/taurex/data/profiles/temperature/temparray.py
@@ -4,9 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 from scipy.interpolate import interp1d
 
 from taurex.output import OutputGroup
+from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .tprofile import TemperatureProfile
 
@@ -16,8 +19,8 @@ class TemperatureArray(TemperatureProfile):
 
     def __init__(
         self,
-        tp_array: t.Optional[npt.ArrayLike] = None,
-        p_points: t.Optional[npt.ArrayLike] = None,
+        tp_array: t.Optional[t.Union[npt.ArrayLike, u.Quantity]] = None,
+        p_points: t.Optional[t.Union[npt.ArrayLike, u.Quantity]] = None,
         reverse: t.Optional[bool] = False,
     ):
         """Initialize the temperature profile.
@@ -25,20 +28,26 @@ class TemperatureArray(TemperatureProfile):
         Parameters
         ----------
         tp_array:
-            Temperature profile array, by default None
+            Temperature profile array in K when unitless, by default None.
         p_points:
-            Pressure profile array, by default None
+            Pressure points in Pa when unitless, by default None.
         reverse : t.Optional[bool], optional
             Reverse the temperature profile, by default False
 
         """
         super().__init__(self.__class__.__name__)
 
-        self._tp_profile = np.array(tp_array)
+        tp_array = convert_to_unit_value(
+            tp_array, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
+        self._tp_profile = np.asarray(tp_array, dtype=get_float_dtype())
         if reverse:
             self._tp_profile = self._tp_profile[::-1]
         if p_points is not None:
-            self._p_profile = np.array(p_points)
+            p_points = convert_to_unit_value(
+                p_points, u.Pa, default_unit=u.Pa
+            )
+            self._p_profile = np.asarray(p_points, dtype=get_float_dtype())
             if reverse:
                 self._p_profile = self._p_profile[::-1]
             self._func = interp1d(

--- a/src/taurex/model/simplemodel.py
+++ b/src/taurex/model/simplemodel.py
@@ -16,6 +16,7 @@ from taurex.temperature import TemperatureProfile
 from taurex.types import ModelOutputType
 from taurex.types import get_float_dtype
 from taurex.util import clip_native_to_wngrid
+from taurex.util import convert_to_unit_value
 
 from .model import ForwardModel
 
@@ -406,11 +407,9 @@ class SimpleForwardModel(ForwardModel):
         spectral_grid:
             Wavenumber grid
         """
-        if isinstance(spectral_grid, u.Quantity):
-            wngrid = spectral_grid.to(u.k, equivalencies=u.spectral()).value
-        else:
-            wngrid = np.asarray(spectral_grid, dtype=get_float_dtype())
-
+        wngrid = convert_to_unit_value(
+            spectral_grid, u.k, equivalencies=u.spectral()
+        )
         wngrid = np.asarray(wngrid, dtype=get_float_dtype())
         # Sort the grid
         wngrid = np.sort(wngrid)

--- a/src/taurex/model/simplemodel.py
+++ b/src/taurex/model/simplemodel.py
@@ -407,9 +407,7 @@ class SimpleForwardModel(ForwardModel):
         spectral_grid:
             Wavenumber grid
         """
-        wngrid = convert_to_unit_value(
-            spectral_grid, u.k, equivalencies=u.spectral()
-        )
+        wngrid = convert_to_unit_value(spectral_grid, u.k, equivalencies=u.spectral())
         wngrid = np.asarray(wngrid, dtype=get_float_dtype())
         # Sort the grid
         wngrid = np.sort(wngrid)

--- a/src/taurex/model/simplemodel.py
+++ b/src/taurex/model/simplemodel.py
@@ -408,8 +408,10 @@ class SimpleForwardModel(ForwardModel):
         """
         if isinstance(spectral_grid, u.Quantity):
             wngrid = spectral_grid.to(u.k, equivalencies=u.spectral()).value
+        else:
+            wngrid = np.asarray(spectral_grid, dtype=get_float_dtype())
 
-        wngrid = np.array(wngrid, dtype=get_float_dtype())
+        wngrid = np.asarray(wngrid, dtype=get_float_dtype())
         # Sort the grid
         wngrid = np.sort(wngrid)
 

--- a/src/taurex/temperature.py
+++ b/src/taurex/temperature.py
@@ -4,6 +4,7 @@ from taurex.data.profiles.temperature import Guillot2010
 from taurex.data.profiles.temperature import Isothermal
 from taurex.data.profiles.temperature import NPoint
 from taurex.data.profiles.temperature import Rodgers2000
+from taurex.data.profiles.temperature import TemperatureArray
 from taurex.data.profiles.temperature import TemperatureFile
 from taurex.data.profiles.temperature import TemperatureProfile
 
@@ -15,4 +16,5 @@ __all__ = [
     "NPoint",
     "Rodgers2000",
     "TemperatureFile",
+    "TemperatureArray",
 ]

--- a/src/taurex/util/__init__.py
+++ b/src/taurex/util/__init__.py
@@ -8,6 +8,7 @@ from .util import clip_native_to_wngrid
 from .util import compute_bin_edges
 from .util import compute_dz
 from .util import conversion_factor
+from .util import convert_to_unit_value
 from .util import create_grid_res
 from .util import decode_string_array
 from .util import ensure_string_utf8
@@ -61,6 +62,7 @@ __all__ = [
     "class_for_name",
     "create_grid_res",
     "conversion_factor",
+    "convert_to_unit_value",
     "compute_dz",
     "has_duplicates",
     "find_closest_pair",

--- a/src/taurex/util/util.py
+++ b/src/taurex/util/util.py
@@ -1023,6 +1023,9 @@ def convert_to_unit_value(
     if default_unit is None:
         return value
 
+    if u.Unit(default_unit) == u.Unit(target_unit):
+        return value
+
     return u.Quantity(value, default_unit).to_value(
         target_unit, equivalencies=equivalencies or []
     )

--- a/src/taurex/util/util.py
+++ b/src/taurex/util/util.py
@@ -987,6 +987,47 @@ def conversion_factor(from_unit: str, to_unit: str) -> float:
     return from_conv.to(to_conv)
 
 
+def convert_to_unit_value(
+    value: t.Any,
+    target_unit: t.Union[str, u.UnitBase],
+    default_unit: t.Optional[t.Union[str, u.UnitBase]] = None,
+    equivalencies: t.Optional[t.Any] = None,
+) -> t.Any:
+    """Return plain numeric data expressed in the target unit.
+
+    Quantity input is converted directly to ``target_unit``. Unitless input
+    keeps its existing meaning unless ``default_unit`` is supplied, in which
+    case that unit is assumed before conversion.
+
+    Parameters
+    ----------
+    value:
+        Scalar, array, or :class:`astropy.units.Quantity` to normalize.
+    target_unit:
+        Unit of the returned numeric value.
+    default_unit:
+        Unit to assume for unitless input. If omitted, unitless values are
+        returned unchanged.
+    equivalencies:
+        Astropy equivalencies to use during conversion.
+
+    Returns
+    -------
+    Any
+        Plain scalar or array values without an attached unit.
+
+    """
+    if isinstance(value, u.Quantity):
+        return value.to_value(target_unit, equivalencies=equivalencies or [])
+
+    if default_unit is None:
+        return value
+
+    return u.Quantity(value, default_unit).to_value(
+        target_unit, equivalencies=equivalencies or []
+    )
+
+
 def compute_dz(altitude: npt.NDArray) -> npt.NDArray:
     """Compute dz from altitude.
 

--- a/tests/model/test_simplemodel.py
+++ b/tests/model/test_simplemodel.py
@@ -1,0 +1,49 @@
+"""Tests for the one-dimensional forward model."""
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from taurex.model.simplemodel import OneDForwardModel
+from taurex.types import get_float_dtype
+
+
+@pytest.fixture
+def model():
+    """Create a minimal model for testing native-grid normalization."""
+    instance = object.__new__(OneDForwardModel)
+    instance._native_grid = None
+    return instance
+
+
+def test_set_native_grid_accepts_plain_array(model):
+    """Plain arrays remain supported and are stored sorted as floats."""
+    model.set_native_grid(np.array([3, 1, 2]))
+
+    np.testing.assert_array_equal(model.nativeWavenumberGrid, [1.0, 2.0, 3.0])
+    assert model.nativeWavenumberGrid.dtype == get_float_dtype()
+
+
+def test_set_native_grid_accepts_wavenumber_quantity(model):
+    """Wavenumber quantities are normalized to the internal unit."""
+    grid = np.array([3.0, 1.0, 2.0]) * u.k
+
+    model.set_native_grid(grid)
+
+    np.testing.assert_allclose(model.nativeWavenumberGrid, [1.0, 2.0, 3.0])
+
+
+def test_set_native_grid_converts_wavelength_quantity(model):
+    """Wavelength quantities are converted using spectral equivalencies."""
+    grid = np.array([1.0, 2.0, 3.0]) * u.micron
+
+    model.set_native_grid(grid)
+
+    expected = np.sort(grid.to(u.k, equivalencies=u.spectral()).value)
+    np.testing.assert_allclose(model.nativeWavenumberGrid, expected)
+
+
+def test_set_native_grid_rejects_incompatible_quantity(model):
+    """Quantities that are not spectral coordinates are rejected."""
+    with pytest.raises(u.UnitConversionError):
+        model.set_native_grid(np.array([1.0, 2.0, 3.0]) * u.kg)

--- a/tests/temperature/test_guillot.py
+++ b/tests/temperature/test_guillot.py
@@ -1,6 +1,7 @@
 """Test Guillot 2010 temperature profile."""
 
 import pytest
+from astropy import units as u
 from hypothesis import given
 from hypothesis import strategies as st
 
@@ -136,3 +137,38 @@ def test_guillot_values():
     Should be a list of inputs and outputs
     """
     pass
+
+
+def test_guillot_accepts_temperature_quantities():
+    """Physical temperature parameters are normalized to Kelvin."""
+    profile = Guillot2010(
+        T_irr=1.5 * u.kK,
+        T_int=u.Quantity(20.0, u.deg_C),
+    )
+
+    assert profile.equilTemperature == pytest.approx(1500.0)
+    assert profile.internalTemperature == pytest.approx(293.15)
+
+
+def test_guillot_temperature_setters_accept_quantities():
+    """Fittable temperature setters normalize Quantity values."""
+    profile = Guillot2010()
+
+    profile.equilTemperature = 2.0 * u.kK
+    profile.internalTemperature = 0.5 * u.kK
+
+    assert profile.equilTemperature == pytest.approx(2000.0)
+    assert profile.internalTemperature == pytest.approx(500.0)
+
+
+@pytest.mark.parametrize("parameter", ["T_irr", "T_int"])
+def test_guillot_rejects_incompatible_temperature_quantity(parameter):
+    """Temperature parameters reject incompatible physical dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        Guillot2010(**{parameter: 1.0 * u.m})
+
+
+def test_guillot_rejects_quantity_below_absolute_zero():
+    """Validation occurs after conversion to the internal Kelvin unit."""
+    with pytest.raises(InvalidModelException, match="Negative temperature"):
+        Guillot2010(T_int=u.Quantity(-300.0, u.deg_C))

--- a/tests/temperature/test_isothermal.py
+++ b/tests/temperature/test_isothermal.py
@@ -1,6 +1,8 @@
 """Test isothermal temperature profile."""
 
 import numpy as np
+import pytest
+from astropy import units as u
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
@@ -31,3 +33,35 @@ def test_isothermal(temperature, another_temperature, nlayers):
     assert iso.isoTemperature == another_temperature
     assert np.all(iso.profile == another_temperature)
     assert params["T"][2]() == another_temperature
+
+
+def test_isothermal_accepts_quantity():
+    """Quantity input is normalized to Kelvin in the generated profile."""
+    iso = Isothermal(T=1.0 * u.kK)
+
+    iso.initialize_profile(nlayers=3)
+
+    assert iso.isoTemperature == pytest.approx(1000.0)
+    np.testing.assert_allclose(iso.profile, [1000.0, 1000.0, 1000.0])
+
+
+def test_isothermal_accepts_celsius_quantity():
+    """Offset temperature units are converted using temperature equivalencies."""
+    iso = Isothermal(T=u.Quantity(20.0, u.deg_C))
+
+    assert iso.isoTemperature == pytest.approx(293.15)
+
+
+def test_isothermal_setter_accepts_quantity():
+    """The fittable temperature setter also accepts Quantity input."""
+    iso = Isothermal()
+
+    iso.isoTemperature = 0.5 * u.kK
+
+    assert iso.isoTemperature == pytest.approx(500.0)
+
+
+def test_isothermal_rejects_incompatible_quantity():
+    """The temperature boundary rejects incompatible dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        Isothermal(T=1.0 * u.m)

--- a/tests/temperature/test_npoint.py
+++ b/tests/temperature/test_npoint.py
@@ -108,7 +108,7 @@ def test_npoint_fitting_setters_accept_quantities():
     ],
 )
 def test_npoint_rejects_incompatible_quantities(parameter, value):
-    """NPoint rejects incompatible temperature and pressure dimensions."""
+    """Reject incompatible NPoint temperature and pressure dimensions."""
     kwargs = {
         "temperature_points": [500.0] if parameter != "temperature_points" else [],
         "pressure_points": [1e4] if parameter != "pressure_points" else [],

--- a/tests/temperature/test_npoint.py
+++ b/tests/temperature/test_npoint.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from astropy import units as u
 from hypothesis import given
 from hypothesis.strategies import floats as st_floats
 from hypothesis.strategies import integers as st_integers
@@ -62,3 +63,57 @@ def test_npoint(params, limit_slope, smoothing_window):
     else:
         # Lets make sure it doesn't crash
         npoint.profile
+
+
+def test_npoint_accepts_quantity_nodes():
+    """Temperature and pressure nodes are normalized to K and Pa."""
+    profile = NPoint(
+        T_surface=1.5 * u.kK,
+        T_top=u.Quantity(0.0, u.deg_C),
+        P_surface=1.0 * u.bar,
+        P_top=1.0 * u.mbar,
+        temperature_points=np.array([500.0]) * u.K,
+        pressure_points=np.array([0.1]) * u.bar,
+    )
+
+    assert profile.temperatureSurface == pytest.approx(1500.0)
+    assert profile.temperatureTop == pytest.approx(273.15)
+    assert profile.pressureSurface == pytest.approx(1e5)
+    assert profile.pressureTop == pytest.approx(100.0)
+    np.testing.assert_allclose(profile._t_points, [500.0])
+    np.testing.assert_allclose(profile._p_points, [1e4])
+
+
+def test_npoint_fitting_setters_accept_quantities():
+    """Generated node setters normalize Quantity input."""
+    profile = NPoint(temperature_points=[500.0], pressure_points=[1e4])
+    parameters = profile.fitting_parameters()
+
+    parameters["T_point1"][3](0.6 * u.kK)
+    parameters["P_point1"][3](0.2 * u.bar)
+
+    assert parameters["T_point1"][2]() == pytest.approx(600.0)
+    assert parameters["P_point1"][2]() == pytest.approx(2e4)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("T_surface", 1.0 * u.m),
+        ("T_top", 1.0 * u.m),
+        ("P_surface", 1.0 * u.s),
+        ("P_top", 1.0 * u.s),
+        ("temperature_points", np.array([1.0]) * u.m),
+        ("pressure_points", np.array([1.0]) * u.s),
+    ],
+)
+def test_npoint_rejects_incompatible_quantities(parameter, value):
+    """NPoint rejects incompatible temperature and pressure dimensions."""
+    kwargs = {
+        "temperature_points": [500.0] if parameter != "temperature_points" else [],
+        "pressure_points": [1e4] if parameter != "pressure_points" else [],
+        parameter: value,
+    }
+
+    with pytest.raises(u.UnitConversionError):
+        NPoint(**kwargs)

--- a/tests/temperature/test_rodgers.py
+++ b/tests/temperature/test_rodgers.py
@@ -1,0 +1,32 @@
+"""Tests for the Rodgers 2000 temperature profile."""
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from taurex.temperature import Rodgers2000
+from taurex.types import get_float_dtype
+
+
+def test_rodgers_accepts_temperature_quantity():
+    """Layer temperatures are normalized to Kelvin."""
+    profile = Rodgers2000(u.Quantity([0.0, 100.0], u.deg_C))
+
+    np.testing.assert_allclose(profile.temperature_layers, [273.15, 373.15])
+    assert profile.temperature_layers.dtype == get_float_dtype()
+
+
+def test_rodgers_fitting_setter_accepts_quantity():
+    """Generated layer setters normalize Quantity input."""
+    profile = Rodgers2000([300.0, 400.0])
+    parameters = profile.fitting_parameters()
+
+    parameters["T_1"][3](0.5 * u.kK)
+
+    assert parameters["T_1"][2]() == pytest.approx(500.0)
+
+
+def test_rodgers_rejects_incompatible_quantity():
+    """Layer temperatures reject incompatible physical dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        Rodgers2000(np.array([1.0, 2.0]) * u.m)

--- a/tests/temperature/test_temparray.py
+++ b/tests/temperature/test_temparray.py
@@ -1,0 +1,66 @@
+"""Tests for array-based temperature profiles."""
+
+import astropy.units as u
+import numpy as np
+import pytest
+
+from taurex.temperature import TemperatureArray
+from taurex.types import get_float_dtype
+
+
+def test_temperature_array_preserves_unitless_kelvin_values():
+    """Plain arrays retain their legacy interpretation in Kelvin."""
+    profile = TemperatureArray(tp_array=[300, 400, 500])
+    profile.initialize_profile(nlayers=3)
+
+    np.testing.assert_allclose(profile.profile, [300.0, 400.0, 500.0])
+    assert profile.profile.dtype == get_float_dtype()
+
+
+def test_temperature_array_accepts_quantity():
+    """Temperature arrays are normalized to Kelvin."""
+    temperatures = u.Quantity([0.0, 100.0], u.deg_C)
+    profile = TemperatureArray(tp_array=temperatures)
+    profile.initialize_profile(nlayers=2)
+
+    np.testing.assert_allclose(profile.profile, [273.15, 373.15])
+
+
+def test_temperature_array_accepts_pressure_quantities():
+    """Interpolation pressure points are normalized to Pa."""
+    profile = TemperatureArray(
+        tp_array=np.array([300.0, 500.0]) * u.K,
+        p_points=np.array([1.0, 0.1]) * u.bar,
+    )
+    profile.initialize_profile(
+        nlayers=2,
+        pressure_profile=np.array([1e5, 1e4]),
+    )
+
+    np.testing.assert_allclose(profile.profile, [300.0, 500.0])
+
+
+def test_temperature_array_reverses_normalized_values():
+    """Reversal is applied after unit normalization."""
+    profile = TemperatureArray(
+        tp_array=np.array([300.0, 500.0]) * u.K,
+        reverse=True,
+    )
+    profile.initialize_profile(nlayers=2)
+
+    np.testing.assert_allclose(profile.profile, [500.0, 300.0])
+
+
+@pytest.mark.parametrize(
+    ("argument", "value"),
+    [
+        ("tp_array", np.array([1.0, 2.0]) * u.m),
+        ("p_points", np.array([1.0, 2.0]) * u.s),
+    ],
+)
+def test_temperature_array_rejects_incompatible_quantities(argument, value):
+    """Array boundaries reject incompatible physical dimensions."""
+    kwargs = {"tp_array": [300.0, 400.0], argument: value}
+
+    with pytest.raises(u.UnitConversionError):
+        TemperatureArray(**kwargs)

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -1,0 +1,55 @@
+"""Tests for planet physical-unit boundaries."""
+
+import astropy.units as u
+import pytest
+
+from taurex.planet import Planet
+
+
+def test_planet_preserves_plain_value_units():
+    """Plain constructor values retain their documented legacy units."""
+    planet = Planet(planet_mass=2.0, planet_radius=3.0, planet_sma=0.5)
+
+    assert planet.get_planet_mass("Mjup") == pytest.approx(2.0)
+    assert planet.get_planet_radius("Rjup") == pytest.approx(3.0)
+    assert planet.get_planet_semimajoraxis("AU") == pytest.approx(0.5)
+
+
+def test_planet_accepts_quantity_constructor_values():
+    """Quantity constructor values are normalized to internal SI units."""
+    mass = 2.0 * u.M_earth
+    radius = 3.0 * u.R_earth
+    semimajor_axis = 1.5e6 * u.km
+
+    planet = Planet(
+        planet_mass=mass,
+        planet_radius=radius,
+        planet_sma=semimajor_axis,
+    )
+
+    assert planet.get_planet_mass("kg") == pytest.approx(mass.to_value(u.kg))
+    assert planet.get_planet_radius("m") == pytest.approx(radius.to_value(u.m))
+    assert planet.get_planet_semimajoraxis("m") == pytest.approx(
+        semimajor_axis.to_value(u.m)
+    )
+
+
+def test_planet_quantity_uses_attached_unit():
+    """A Quantity's attached unit takes precedence over the fallback unit."""
+    planet = Planet()
+
+    planet.set_planet_radius(1.0 * u.km, unit="Rjup")
+
+    assert planet.get_planet_radius("m") == pytest.approx(1000.0)
+
+
+@pytest.mark.parametrize(
+    "setter_name",
+    ["set_planet_mass", "set_planet_radius", "set_planet_semimajoraxis"],
+)
+def test_planet_rejects_incompatible_quantity(setter_name):
+    """Planet setters reject quantities with incompatible dimensions."""
+    planet = Planet()
+
+    with pytest.raises(u.UnitConversionError):
+        getattr(planet, setter_name)(1.0 * u.s)

--- a/tests/test_pressure.py
+++ b/tests/test_pressure.py
@@ -9,6 +9,7 @@ from hypothesis.strategies import floats
 from hypothesis.strategies import integers
 
 from taurex.data.profiles.pressure import LogPressureProfile
+from taurex.pressure import ArrayPressureProfile
 from taurex.pressure import PressureProfile
 from taurex.pressure import SimplePressureProfile
 
@@ -123,3 +124,32 @@ def test_log_pressure_rejects_incompatible_quantity(parameter):
 
     with pytest.raises(u.UnitConversionError):
         LogPressureProfile(**kwargs)
+
+
+def test_array_pressure_accepts_quantity():
+    """Array pressure profiles are normalized to Pa."""
+    profile = ArrayPressureProfile(np.array([1.0, 0.1]) * u.bar)
+
+    np.testing.assert_allclose(profile.profile, [1e5, 1e4])
+
+
+def test_array_pressure_preserves_unitless_pa_values():
+    """Plain arrays retain their legacy interpretation in Pa."""
+    profile = ArrayPressureProfile([1e5, 1e4], reverse=True)
+
+    np.testing.assert_allclose(profile.profile, [1e4, 1e5])
+
+
+def test_array_pressure_computes_levels():
+    """The normalized pressure array is used to compute level pressures."""
+    profile = ArrayPressureProfile([1e5, 1e4])
+
+    profile.compute_pressure_profile()
+
+    assert profile.pressure_profile_levels.shape == (3,)
+
+
+def test_array_pressure_rejects_incompatible_quantity():
+    """Pressure arrays reject incompatible physical dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        ArrayPressureProfile(np.array([1.0, 2.0]) * u.m)

--- a/tests/test_pressure.py
+++ b/tests/test_pressure.py
@@ -2,11 +2,13 @@
 
 import numpy as np
 import pytest
+from astropy import units as u
 from hypothesis import example
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
 
+from taurex.data.profiles.pressure import LogPressureProfile
 from taurex.pressure import PressureProfile
 from taurex.pressure import SimplePressureProfile
 
@@ -73,3 +75,51 @@ def test_simple_pressure(min_pressure, max_pressure, nlayers):
 
         assert np.all(pressure_profile_levels[:-1] > pressure_profile)
         assert np.all(pressure_profile_levels[1:] < pressure_profile)
+
+
+def test_log_pressure_accepts_quantity_bounds():
+    """Pressure bounds are normalized to Pa before building the profile."""
+    profile = LogPressureProfile(
+        nlayers=10,
+        atm_min_pressure=1.0 * u.mbar,
+        atm_max_pressure=2.0 * u.bar,
+    )
+
+    profile.compute_pressure_profile()
+
+    assert profile.minAtmospherePressure == pytest.approx(100.0)
+    assert profile.maxAtmospherePressure == pytest.approx(2e5)
+    assert profile.pressure_profile_levels.min() == pytest.approx(100.0)
+    assert profile.pressure_profile_levels.max() == pytest.approx(2e5)
+
+
+def test_log_pressure_preserves_unitless_pa_bounds():
+    """Plain pressure bounds retain their legacy interpretation in Pa."""
+    profile = LogPressureProfile(
+        nlayers=10,
+        atm_min_pressure=100.0,
+        atm_max_pressure=2e5,
+    )
+
+    assert profile.minAtmospherePressure == pytest.approx(100.0)
+    assert profile.maxAtmospherePressure == pytest.approx(2e5)
+
+
+def test_log_pressure_setters_accept_quantities():
+    """Fittable pressure setters also normalize Quantity input to Pa."""
+    profile = LogPressureProfile()
+
+    profile.minAtmospherePressure = 2.0 * u.mbar
+    profile.maxAtmospherePressure = 3.0 * u.bar
+
+    assert profile.minAtmospherePressure == pytest.approx(200.0)
+    assert profile.maxAtmospherePressure == pytest.approx(3e5)
+
+
+@pytest.mark.parametrize("parameter", ["atm_min_pressure", "atm_max_pressure"])
+def test_log_pressure_rejects_incompatible_quantity(parameter):
+    """Pressure bounds reject quantities with incompatible dimensions."""
+    kwargs = {parameter: 1.0 * u.m}
+
+    with pytest.raises(u.UnitConversionError):
+        LogPressureProfile(**kwargs)

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -178,9 +178,7 @@ def test_convert_to_unit_value_uses_default_unit():
     """A default unit can be assumed for otherwise unitless input."""
     from taurex.util import convert_to_unit_value
 
-    np.testing.assert_allclose(
-        convert_to_unit_value([1.0, 2.0], "m", "km"), [1e3, 2e3]
-    )
+    np.testing.assert_allclose(convert_to_unit_value([1.0, 2.0], "m", "km"), [1e3, 2e3])
 
 
 def test_convert_to_unit_value_preserves_matching_default_unit():

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -82,6 +82,25 @@ def test_grid_res(res):
     assert round(np.mean(wn / np.gradient(wn))) == res
 
 
+def test_set_native_grid_quantity():
+    """Test spectral grids accept plain arrays and Astropy quantity inputs."""
+    import astropy.units as u
+
+    from taurex.model.simplemodel import OneDForwardModel
+
+    plain_model = OneDForwardModel("plain_model")
+    plain_grid = np.array([1.0, 2.0, 3.0])
+    plain_model.set_native_grid(plain_grid)
+    np.testing.assert_allclose(plain_model.nativeWavenumberGrid, np.sort(plain_grid))
+
+    quantity_model = OneDForwardModel("quantity_model")
+    grid = np.array([1.0, 2.0, 3.0]) * u.micron
+    quantity_model.set_native_grid(grid)
+
+    expected = np.sort(grid.to(u.k, equivalencies=u.spectral()).value)
+    np.testing.assert_allclose(quantity_model.nativeWavenumberGrid, expected)
+
+
 def test_molecule_sanitization_same():
     """Test molecule sanitization doesn't change already correct names."""
     from taurex.util import sanitize_molecule_string

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -164,6 +164,62 @@ def test_conversion_factor():
     assert conversion_factor("erg/(cm**2*s*Hz)", "Jy") == 1e23
 
 
+def test_convert_to_unit_value_preserves_unitless_input():
+    """Unitless values retain their existing internal-unit meaning."""
+    from taurex.util import convert_to_unit_value
+
+    values = np.array([1.0, 2.0, 3.0])
+
+    assert convert_to_unit_value(2.0, "m") == 2.0
+    assert convert_to_unit_value(values, "m") is values
+
+
+def test_convert_to_unit_value_uses_default_unit():
+    """A default unit can be assumed for otherwise unitless input."""
+    from taurex.util import convert_to_unit_value
+
+    np.testing.assert_allclose(
+        convert_to_unit_value([1.0, 2.0], "m", "km"), [1e3, 2e3]
+    )
+
+
+def test_convert_to_unit_value_converts_quantity():
+    """Quantity input is returned as plain values in the target unit."""
+    import astropy.units as u
+
+    from taurex.util import convert_to_unit_value
+
+    values = np.array([1.0, 2.0]) * u.km
+
+    converted = convert_to_unit_value(values, u.m)
+
+    np.testing.assert_allclose(converted, [1e3, 2e3])
+    assert not isinstance(converted, u.Quantity)
+
+
+def test_convert_to_unit_value_supports_equivalencies():
+    """Conversions can use Astropy equivalencies such as spectral units."""
+    import astropy.units as u
+
+    from taurex.util import convert_to_unit_value
+
+    value = 1.0 * u.micron
+
+    assert convert_to_unit_value(
+        value, u.k, equivalencies=u.spectral()
+    ) == pytest.approx(10000.0)
+
+
+def test_convert_to_unit_value_rejects_incompatible_quantity():
+    """Incompatible Quantity input retains Astropy's clear error."""
+    import astropy.units as u
+
+    from taurex.util import convert_to_unit_value
+
+    with pytest.raises(u.UnitConversionError):
+        convert_to_unit_value(1.0 * u.kg, u.m)
+
+
 def test_wngrid_clip():
     """Test clipping native grid to wavenumber grid."""
     from taurex.binning import FluxBinner

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -82,25 +82,6 @@ def test_grid_res(res):
     assert round(np.mean(wn / np.gradient(wn))) == res
 
 
-def test_set_native_grid_quantity():
-    """Test spectral grids accept plain arrays and Astropy quantity inputs."""
-    import astropy.units as u
-
-    from taurex.model.simplemodel import OneDForwardModel
-
-    plain_model = OneDForwardModel("plain_model")
-    plain_grid = np.array([1.0, 2.0, 3.0])
-    plain_model.set_native_grid(plain_grid)
-    np.testing.assert_allclose(plain_model.nativeWavenumberGrid, np.sort(plain_grid))
-
-    quantity_model = OneDForwardModel("quantity_model")
-    grid = np.array([1.0, 2.0, 3.0]) * u.micron
-    quantity_model.set_native_grid(grid)
-
-    expected = np.sort(grid.to(u.k, equivalencies=u.spectral()).value)
-    np.testing.assert_allclose(quantity_model.nativeWavenumberGrid, expected)
-
-
 def test_molecule_sanitization_same():
     """Test molecule sanitization doesn't change already correct names."""
     from taurex.util import sanitize_molecule_string

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -183,6 +183,15 @@ def test_convert_to_unit_value_uses_default_unit():
     )
 
 
+def test_convert_to_unit_value_preserves_matching_default_unit():
+    """No conversion is needed when default and target units match."""
+    from taurex.util import convert_to_unit_value
+
+    values = np.array([1.0, 2.0, 3.0])
+
+    assert convert_to_unit_value(values, "K", "K") is values
+
+
 def test_convert_to_unit_value_converts_quantity():
     """Quantity input is returned as plain values in the target unit."""
     import astropy.units as u


### PR DESCRIPTION
## Summary

This PR adds backward-compatible support for Astropy `Quantity` inputs at
several public TauREx input boundaries.

Quantity inputs are converted to the internal units used by TauREx, while
existing unitless NumPy arrays and scalar values retain their documented
meaning. Internally, values remain plain numeric data.

Related to #33.

## Changes

- Add a reusable `convert_to_unit_value` helper.
- Accept wavelength and wavenumber quantities in native spectral grids.
- Accept quantities for planet:
  - mass;
  - radius;
  - semi-major axis.
- Accept pressure quantities for:
  - atmospheric minimum and maximum pressure;
  - pressure fitting setters;
  - array-based pressure profiles.
- Accept temperature quantities for:
  - isothermal profiles;
  - array-based profiles and their pressure coordinates;
  - Guillot irradiation and internal temperatures;
  - NPoint temperature and pressure nodes;
  - Rodgers layer temperatures.
- Support offset temperature units such as degrees Celsius.
- Reject quantities with incompatible physical dimensions.
- Expose `TemperatureArray` through the public temperature API.
- Fix `ArrayPressureProfile` storing its input under `pressure_array` while
  the implementation reads `pressure_profile`.

## Backward compatibility

Plain numeric inputs continue to use the existing implicit units:

- spectral grids: internal wavenumber units;
- planet mass: Jupiter masses;
- planet radius: Jupiter radii;
- semi-major axis: AU;
- pressure: Pa;
- temperature: K.

Astropy `Quantity` inputs use their attached units and are normalized at the
API boundary. No unit objects are propagated through the numerical model
internals.

## Testing

Added regression tests for:

- legacy scalar and NumPy-array inputs;
- compatible quantities in different units;
- wavelength-to-wavenumber spectral equivalencies;
- Celsius-to-Kelvin conversion;
- constructor and fitting-setter inputs;
- incompatible-unit rejection.

Validation performed:

- Black: passed
- isort: passed
- Flake8: passed
- pytest: 194 passed

The existing timing-sensitive blackbody test was excluded from the final
suite because its first cold invocation can exceed its 400 ms Hypothesis
deadline. It passes when run separately and is unrelated to these changes.

### Type checking

The strict mypy configuration is not currently a green project-wide check.
It reports existing typing issues around the fitting-property decorators,
optional values, and untyped dependencies. Astropy and SciPy also do not
provide all the type information required by the current configuration.

The type hints added in this PR describe the newly accepted `Quantity`
inputs, but the broader mypy findings should be addressed separately rather
than expanding the scope of this PR.

## Scope

This PR establishes the first compatibility layer for unit-aware physical
inputs. Density-based representations for non-vapour species require
additional chemistry and profile design and are intentionally left for a
follow-up change.
                                                                  