### PR TITLE
33 astropy units followup

### DIFF
--- a/docs/devel/index.rst
+++ b/docs/devel/index.rst
@@ -10,6 +10,7 @@ Developers guide
 
     Overview <overview>
     Guidelines <guidelines>
+    Physical units <units>
     Basics <basics>
     Retrieval Parameters <fittingparameters>
     Building Components <components>

--- a/docs/devel/plugins.rst
+++ b/docs/devel/plugins.rst
@@ -22,6 +22,13 @@ The plugin system can be used to add the following new components:
     - :class:`~taurex.optimizer.optimizer.Optimizer`
     - :class:`~taurex.mixin.core.Mixin`
 
+Chemistry plugins representing non-vapour species by particle number density
+should implement ``condensateNumberDensityProfile`` with shape
+``(ncondensates, nlayers)``. Values are plain numerics in :math:`m^{-3}`;
+``normalize_condensate_number_density`` converts compatible Astropy quantities
+at the plugin input boundary. This interface is separate from the
+dimensionless ``condensateMixProfile`` representation.
+
 Refer to the :ref:`Developers` on how to build each individual component.
 This guide will outline how to package your new components into a TauREx plugin.
 

--- a/docs/devel/units.rst
+++ b/docs/devel/units.rst
@@ -1,0 +1,61 @@
+.. _physical-units:
+
+========================
+Physical-unit boundaries
+========================
+
+TauREx accepts :class:`astropy.units.Quantity` at public component boundaries
+where an input has an unambiguous physical meaning. Quantities are converted
+immediately to the component's documented internal unit and stored as plain
+numeric values. Unitless input retains its historical TauREx meaning for
+backwards compatibility.
+
+This policy applies to constructor arguments and public or fitting setters for
+the following component groups:
+
+* planetary, stellar, pressure, and temperature profiles;
+* gas abundances, bulk-chemistry ratios, and condensate number densities;
+* cloud and Mie parameters;
+* spectral grids supplied to binners and forward models.
+
+For example, pressure is stored in Pa, temperature in K, spectral wavenumber
+in cm⁻¹, particle number density in m⁻³, and dimensionless quantities as plain
+fractions. Incompatible dimensions raise Astropy's ``UnitConversionError``.
+The shared :func:`taurex.util.convert_to_unit_value` helper implements this
+boundary conversion.
+
+Condensate representations
+---------------------------
+
+``condensateMixProfile`` remains a dimensionless representation.
+``condensateNumberDensityProfile`` is a separate optional chemistry interface
+for non-vapour particle number densities, with shape
+``(ncondensates, nlayers)`` and internal unit m⁻³. Chemistry plugins should use
+``normalize_condensate_number_density`` when accepting equivalent Quantity
+input.
+
+Number density is not inferred from mass density. Converting kg/m³ to m⁻³
+requires information such as particle mass or material density and particle
+size, which is not part of the base chemistry interface.
+
+Scope boundaries
+----------------
+
+Unit conversion is deliberately not performed inside low-level numerical
+kernels. Opacity interpolation, radiative-transfer integration, and similar
+internal routines continue to consume numeric arrays in their documented
+internal units.
+
+The following public-looking inputs also remain outside the generic Quantity
+contract because their representation is not unambiguous:
+
+* heterogeneous spectrum and instrument tables, whose columns have different
+  units and therefore cannot be represented by one two-dimensional Quantity;
+* file-driven legacy light-curve inputs;
+* ``PowerGas.beta``, whose effective unit depends on the empirical coefficient
+  convention;
+* ``PhoenixStar.magnitudeK``, which requires a separate decision about
+  logarithmic magnitude units.
+
+Supporting these inputs requires a dedicated file schema or component-specific
+API rather than implicit conversion at a numeric boundary.

--- a/docs/user/taurex/chemistry.rst
+++ b/docs/user/taurex/chemistry.rst
@@ -89,6 +89,10 @@ Keywords
 |                |                             | gas                       |         |
 +----------------+-----------------------------+---------------------------+---------+
 
+``ratio`` and ``base_metallicity`` accept dimensionless Astropy quantities.
+For example, ``10 * u.percent`` is stored internally as ``0.1``. The generated
+fill-gas fitting parameters use the same dimensionless contract.
+
 ------------------
 Fitting Parameters
 ------------------

--- a/docs/user/taurex/models.rst
+++ b/docs/user/taurex/models.rst
@@ -396,7 +396,7 @@ Keywords
 +--------------------+--------------+----------------------------------+
 | Variable           | Type         | Description                      |
 +--------------------+--------------+----------------------------------+
-| ``flat_mix_ratio`` | :obj:`float` | Opacity value                    |
+| ``flat_mix_ratio`` | :obj:`float` | Effective opacity in m2          |
 +--------------------+--------------+----------------------------------+
 | ``flat_bottomP``   | :obj:`float` | Bottom of absorbing region in Pa |
 +--------------------+--------------+----------------------------------+
@@ -410,7 +410,7 @@ Fitting Parameters
 +--------------------+--------------+----------------------------------+
 | Parameter          | Type         | Description                      |
 +--------------------+--------------+----------------------------------+
-| ``flat_mix_ratio`` | :obj:`float` | Opacity value                    |
+| ``flat_mix_ratio`` | :obj:`float` | Effective opacity in m2          |
 +--------------------+--------------+----------------------------------+
 | ``flat_bottomP``   | :obj:`float` | Bottom of absorbing region in Pa |
 +--------------------+--------------+----------------------------------+

--- a/docs/user/taurex/models.rst
+++ b/docs/user/taurex/models.rst
@@ -197,7 +197,7 @@ Keywords
 +-----------------------+--------------+----------------------------+
 | ``lee_mie_q``         | :obj:`float` | Extinction coefficient     |
 +-----------------------+--------------+----------------------------+
-| ``lee_mie_mix_ratio`` | :obj:`float` | Mixing ratio in atmosphere |
+| ``lee_mie_mix_ratio`` | :obj:`float` | Number density (m^-3)      |
 +-----------------------+--------------+----------------------------+
 | ``lee_mie_bottomP``   | :obj:`float` | Bottom of cloud deck in Pa |
 +-----------------------+--------------+----------------------------+
@@ -215,7 +215,7 @@ Fitting Parameters
 +-----------------------+--------------+----------------------------+
 | ``lee_mie_q``         | :obj:`float` | Extinction coefficient     |
 +-----------------------+--------------+----------------------------+
-| ``lee_mie_mix_ratio`` | :obj:`float` | Mixing ratio in atmosphere |
+| ``lee_mie_mix_ratio`` | :obj:`float` | Number density (m^-3)      |
 +-----------------------+--------------+----------------------------+
 | ``lee_mie_bottomP``   | :obj:`float` | Bottom of cloud deck in Pa |
 +-----------------------+--------------+----------------------------+

--- a/docs/user/taurex/planet.rst
+++ b/docs/user/taurex/planet.rst
@@ -31,6 +31,11 @@ Keywords
 | ``transit_time``    | :obj:`float` | Transit time in seconds  | 3000.0  |
 +---------------------+--------------+--------------------------+---------+
 
+Physical quantities are normalized to the documented units. For example,
+``48 * u.hour`` is stored as an orbital period of two days and
+``50 * u.min`` as a transit time of 3000 seconds. Impact parameter and albedo
+accept dimensionless quantities such as percentages.
+
 ------------------
 Fitting Parameters
 ------------------

--- a/docs/user/taurex/star.rst
+++ b/docs/user/taurex/star.rst
@@ -45,6 +45,10 @@ Keywords
 | ``magnitudeK``   | :obj:`float` | Magnitude in K-band        | 10.0    |
 +------------------+--------------+----------------------------+---------+
 
+The physical inputs ``temperature``, ``radius``, ``mass`` and ``distance``
+also accept :class:`astropy.units.Quantity`. Unitless values retain the units
+listed above. ``metallicity`` accepts a dimensionless Quantity.
+
 --------
 Examples
 --------
@@ -91,6 +95,10 @@ Keywords
 +------------------+--------------+----------------------------+--------------+
 | ``magnitudeK``   | :obj:`float` | Magnitude in K-band        | 10.0         |
 +------------------+--------------+----------------------------+--------------+
+
+The physical inputs ``temperature``, ``radius``, ``mass`` and ``distance``
+also accept :class:`astropy.units.Quantity`. Unitless values retain the units
+listed above. ``metallicity`` accepts a dimensionless Quantity.
 
 --------
 Examples

--- a/docs/user/taurex/temperature.rst
+++ b/docs/user/taurex/temperature.rst
@@ -85,6 +85,10 @@ Guillot 2010 Profile
 TP profile from Guillot 2010, A&A, 520, A27 (equation 49)
 Using modified 2stream approx. from Line et al. 2012, ApJ, 749,93 (equation 19)
 
+Temperature quantities are converted to K, opacity quantities to m²/kg, and
+``alpha`` quantities to a dimensionless fraction. Unitless values retain these
+documented internal units.
+
 .. figure::  _static/guillot.png
    :align:   left
    :width: 80%
@@ -99,11 +103,11 @@ Keywords
 +--------------+--------------+---------------------------------------------+---------+
 | ``T_irr``    | :obj:`float` | Planet equilibrium temperature (K)          | 1500    |
 +--------------+--------------+---------------------------------------------+---------+
-| ``kappa_ir`` | :obj:`float` | mean infra-red opacity                      | 0.01    |
+| ``kappa_ir`` | :obj:`float` | mean infra-red opacity (m²/kg)              | 0.01    |
 +--------------+--------------+---------------------------------------------+---------+
-| ``kappa_v1`` | :obj:`float` | mean optical opacity one                    | 0.005   |
+| ``kappa_v1`` | :obj:`float` | mean optical opacity one (m²/kg)            | 0.005   |
 +--------------+--------------+---------------------------------------------+---------+
-| ``kappa_v2`` | :obj:`float` | mean optical opacity two                    | 0.005   |
+| ``kappa_v2`` | :obj:`float` | mean optical opacity two (m²/kg)            | 0.005   |
 +--------------+--------------+---------------------------------------------+---------+
 | ``alpha``    | :obj:`float` | ratio between ``kappa_v1`` and ``kappa_v2`` | 0.5     |
 +--------------+--------------+---------------------------------------------+---------+
@@ -117,11 +121,11 @@ Fitting Parameters
 +--------------+--------------+---------------------------------------------+
 | ``T_irr``    | :obj:`float` | Planet equilibrium temperature (K)          |
 +--------------+--------------+---------------------------------------------+
-| ``kappa_ir`` | :obj:`float` | mean infra-red opacity                      |
+| ``kappa_ir`` | :obj:`float` | mean infra-red opacity (m²/kg)              |
 +--------------+--------------+---------------------------------------------+
-| ``kappa_v1`` | :obj:`float` | mean optical opacity one                    |
+| ``kappa_v1`` | :obj:`float` | mean optical opacity one (m²/kg)            |
 +--------------+--------------+---------------------------------------------+
-| ``kappa_v2`` | :obj:`float` | mean optical opacity two                    |
+| ``kappa_v2`` | :obj:`float` | mean optical opacity two (m²/kg)            |
 +--------------+--------------+---------------------------------------------+
 | ``alpha``    | :obj:`float` | ratio between ``kappa_v1`` and ``kappa_v2`` |
 +--------------+--------------+---------------------------------------------+

--- a/src/taurex/binning/fluxbinner.py
+++ b/src/taurex/binning/fluxbinner.py
@@ -4,10 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex import OutputSize
 from taurex.types import get_float_dtype
 from taurex.util import compute_bin_edges
+from taurex.util import convert_to_unit_value
 
 from ..types import ModelOutputType
 from .binner import BinDownType
@@ -243,21 +245,25 @@ class FluxBinner(Binner):
         Parameters
         ----------
         wngrid: :obj:`array`, optional
-            Wavenumber grid. If not set, then ``wlgrid`` must be.
+            Wavenumber grid. Quantity values are converted to inverse centimetres.
+            If not set, then ``wlgrid`` must be.
 
         wngrid_width: :obj:`array`, optional
             Must have same shape as ``wngrid``
             Full bin widths for each wavenumber grid point
-            given in ``wngrid``. If not provided then
+            given in ``wngrid``. Quantity values are converted to inverse centimetres.
+            If not provided then
             this is automatically computed from ``wngrid``.
 
         wlgrid: :obj:`array`, optional
-            Wavelength grid. If not set, then ``wngrid`` must be.
+            Wavelength grid. Quantity values are converted to microns.
+            If not set, then ``wngrid`` must be.
 
         wlgrid_width: :obj:`array`, optional
             Must have same shape as ``wlgrid``
             Full bin widths for each wavelength grid point
-            given in ``wlgrid``. If not provided then
+            given in ``wlgrid``. Quantity values are converted to microns.
+            If not provided then
             this is automatically computed from ``wlgrid``.
         """
         super().__init__()
@@ -272,11 +278,25 @@ class FluxBinner(Binner):
             raise ValueError("You cannot use wngrid_width with wlgrid")
 
         if wngrid is not None:
+            wngrid = np.asarray(
+                convert_to_unit_value(wngrid, u.k, equivalencies=u.spectral())
+            )
+            if wngrid_width is not None:
+                wngrid_width = np.asarray(
+                    convert_to_unit_value(wngrid_width, u.k)
+                )
             sort_grid = wngrid.argsort()
             self._bin_centers = wngrid[sort_grid]
             self._bin_widths = wngrid_width
             self._in_wl = False
         else:
+            wlgrid = np.asarray(
+                convert_to_unit_value(wlgrid, u.micron, equivalencies=u.spectral())
+            )
+            if wlgrid_width is not None:
+                wlgrid_width = np.asarray(
+                    convert_to_unit_value(wlgrid_width, u.micron)
+                )
             sort_grid = wlgrid.argsort()
             self._bin_centers = wlgrid[sort_grid]
             self._bin_widths = wlgrid_width

--- a/src/taurex/binning/fluxbinner.py
+++ b/src/taurex/binning/fluxbinner.py
@@ -282,9 +282,7 @@ class FluxBinner(Binner):
                 convert_to_unit_value(wngrid, u.k, equivalencies=u.spectral())
             )
             if wngrid_width is not None:
-                wngrid_width = np.asarray(
-                    convert_to_unit_value(wngrid_width, u.k)
-                )
+                wngrid_width = np.asarray(convert_to_unit_value(wngrid_width, u.k))
             sort_grid = wngrid.argsort()
             self._bin_centers = wngrid[sort_grid]
             self._bin_widths = wngrid_width
@@ -294,9 +292,7 @@ class FluxBinner(Binner):
                 convert_to_unit_value(wlgrid, u.micron, equivalencies=u.spectral())
             )
             if wlgrid_width is not None:
-                wlgrid_width = np.asarray(
-                    convert_to_unit_value(wlgrid_width, u.micron)
-                )
+                wlgrid_width = np.asarray(convert_to_unit_value(wlgrid_width, u.micron))
             sort_grid = wlgrid.argsort()
             self._bin_centers = wlgrid[sort_grid]
             self._bin_widths = wlgrid_width

--- a/src/taurex/binning/simplebinner.py
+++ b/src/taurex/binning/simplebinner.py
@@ -4,10 +4,12 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex import OutputSize
 from taurex.util import bindown
 from taurex.util import compute_bin_edges
+from taurex.util import convert_to_unit_value
 from taurex.util import wnwidth_to_wlwidth
 
 from ..types import ModelOutputType
@@ -29,12 +31,14 @@ class SimpleBinner(Binner):
     Parameters
     ----------
     wngrid: :obj:`array`
-        Wavenumber grid
+        Wavenumber grid. Quantity values are converted to inverse centimetres;
+        wavelength quantities are also accepted.
 
     wngrid_width: :obj:`array`, optional
         Must have same shape as ``wngrid``
         Full bin widths for each wavenumber grid point
-        given in ``wngrid``. If not provided then
+        given in ``wngrid``. Quantity values are converted to inverse centimetres.
+        If not provided then
         this is automatically computed from ``wngrid``.
 
     """
@@ -58,8 +62,14 @@ class SimpleBinner(Binner):
             this is automatically computed from ``wngrid``.
 
         """
-        self._wngrid = wngrid
-        self._wn_width = wngrid_width
+        self._wngrid = np.asarray(
+            convert_to_unit_value(wngrid, u.k, equivalencies=u.spectral())
+        )
+        self._wn_width = (
+            None
+            if wngrid_width is None
+            else np.asarray(convert_to_unit_value(wngrid_width, u.k))
+        )
         if self._wn_width is None:
             self._wn_width = compute_bin_edges(self._wngrid)[-1]
 

--- a/src/taurex/contributions/flatmie.py
+++ b/src/taurex/contributions/flatmie.py
@@ -4,11 +4,13 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.model import OneDForwardModel
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .contribution import Contribution
 
@@ -23,16 +25,16 @@ class FlatMieContribution(Contribution):
 
     def __init__(
         self,
-        flat_mix_ratio: float = 1e-10,
-        flat_bottomP: float = -1,  # noqa: N803
-        flat_topP: float = -1,
+        flat_mix_ratio: t.Union[float, u.Quantity] = 1e-10,
+        flat_bottomP: t.Union[float, u.Quantity] = -1,  # noqa: N803
+        flat_topP: t.Union[float, u.Quantity] = -1,
     ) -> None:
         """Initialize FlatMieContribution.
 
         Parameters
         ----------
-        flat_mix_ratio: float
-            Opacity value
+        flat_mix_ratio: float or astropy.units.Quantity
+            Effective opacity in m2
 
         flat_bottomP: float
             Bottom of absorbing region in Pa
@@ -43,9 +45,19 @@ class FlatMieContribution(Contribution):
         """
         super().__init__("Mie")
 
-        self._mie_mix = flat_mix_ratio
-        self._mie_bottom_pressure = flat_bottomP
-        self._mie_top_pressure = flat_topP
+        self._mie_mix = self._normalize_opacity(flat_mix_ratio)
+        self._mie_bottom_pressure = self._normalize_pressure(flat_bottomP)
+        self._mie_top_pressure = self._normalize_pressure(flat_topP)
+
+    @staticmethod
+    def _normalize_opacity(value: t.Any) -> t.Any:
+        """Convert effective opacity to plain numeric values in m2."""
+        return convert_to_unit_value(value, u.m**2, default_unit=u.m**2)
+
+    @staticmethod
+    def _normalize_pressure(value: t.Any) -> t.Any:
+        """Convert pressure to plain numeric values in Pa."""
+        return convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @fitparam(
         param_name="flat_topP",
@@ -59,8 +71,8 @@ class FlatMieContribution(Contribution):
         return self._mie_top_pressure
 
     @mieTopPressure.setter
-    def mieTopPressure(self, value: float) -> None:  # noqa: N802
-        self._mie_top_pressure = value
+    def mieTopPressure(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
+        self._mie_top_pressure = self._normalize_pressure(value)
 
     @fitparam(
         param_name="flat_bottomP",
@@ -74,8 +86,10 @@ class FlatMieContribution(Contribution):
         return self._mie_bottom_pressure
 
     @mieBottomPressure.setter
-    def mieBottomPressure(self, value: float) -> None:  # noqa: N802
-        self._mie_bottom_pressure = value
+    def mieBottomPressure(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
+        self._mie_bottom_pressure = self._normalize_pressure(value)
 
     @fitparam(
         param_name="flat_mix_ratio",
@@ -89,8 +103,8 @@ class FlatMieContribution(Contribution):
         return self._mie_mix
 
     @mieMixing.setter
-    def mieMixing(self, value: float) -> None:  # noqa: N802
-        self._mie_mix = value
+    def mieMixing(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
+        self._mie_mix = self._normalize_opacity(value)
 
     def prepare_each(
         self, model: OneDForwardModel, wngrid: npt.NDArray[np.float64]

--- a/src/taurex/contributions/leemie.py
+++ b/src/taurex/contributions/leemie.py
@@ -4,11 +4,13 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.model import OneDForwardModel
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .contribution import Contribution
 
@@ -34,8 +36,8 @@ class LeeMieContribution(Contribution):
     lee_mie_q: float
         Extinction coefficient
 
-    lee_mie_mix_ratio: float
-        Mixing ratio in atmosphere in particles/m3
+    lee_mie_mix_ratio: float or astropy.units.Quantity
+        Particle number density in particles/m3
 
     lee_mie_bottomP: float
         Bottom of cloud deck in Pa
@@ -113,11 +115,11 @@ class LeeMieContribution(Contribution):
 
     def __init__(
         self,
-        lee_mie_radius: t.Optional[float] = 0.01,
-        lee_mie_q: t.Optional[float] = 40,
-        lee_mie_mix_ratio: t.Optional[float] = 1e-10,
-        lee_mie_bottomP: t.Optional[float] = -1,  # noqa: N803
-        lee_mie_topP: t.Optional[float] = -1,
+        lee_mie_radius: t.Optional[t.Union[float, u.Quantity]] = 0.01,
+        lee_mie_q: t.Optional[t.Union[float, u.Quantity]] = 40,
+        lee_mie_mix_ratio: t.Optional[t.Union[float, u.Quantity]] = 1e-10,
+        lee_mie_bottomP: t.Optional[t.Union[float, u.Quantity]] = -1,  # noqa: N803
+        lee_mie_topP: t.Optional[t.Union[float, u.Quantity]] = -1,
     ) -> None:
         """Initialize LeeMieContribution.
 
@@ -129,8 +131,8 @@ class LeeMieContribution(Contribution):
         lee_mie_q: float
             Extinction coefficient
 
-        lee_mie_mix_ratio: float
-            Mixing ratio in atmosphere in particles/m3
+        lee_mie_mix_ratio: float or astropy.units.Quantity
+            Particle number density in particles/m3
 
         lee_mie_bottomP: float
             Bottom of cloud deck in Pa
@@ -141,11 +143,35 @@ class LeeMieContribution(Contribution):
         """
         super().__init__("Mie")
 
-        self._mie_radius = lee_mie_radius
-        self._mie_q = lee_mie_q
-        self._mie_mix = lee_mie_mix_ratio
-        self._mie_bottom_pressure = lee_mie_bottomP
-        self._mie_top_pressure = lee_mie_topP
+        self._mie_radius = self._normalize_radius(lee_mie_radius)
+        self._mie_q = self._normalize_dimensionless(lee_mie_q)
+        self._mie_mix = self._normalize_number_density(lee_mie_mix_ratio)
+        self._mie_bottom_pressure = self._normalize_pressure(lee_mie_bottomP)
+        self._mie_top_pressure = self._normalize_pressure(lee_mie_topP)
+
+    @staticmethod
+    def _normalize_radius(value: t.Any) -> t.Any:
+        """Convert a particle radius to plain numeric microns."""
+        return convert_to_unit_value(value, u.um, default_unit=u.um)
+
+    @staticmethod
+    def _normalize_dimensionless(value: t.Any) -> t.Any:
+        """Convert a dimensionless quantity to plain numeric form."""
+        return convert_to_unit_value(
+            value,
+            u.dimensionless_unscaled,
+            default_unit=u.dimensionless_unscaled,
+        )
+
+    @staticmethod
+    def _normalize_number_density(value: t.Any) -> t.Any:
+        """Convert particle number density to plain numeric values in m^-3."""
+        return convert_to_unit_value(value, u.m**-3, default_unit=u.m**-3)
+
+    @staticmethod
+    def _normalize_pressure(value: t.Any) -> t.Any:
+        """Convert pressure to plain numeric values in Pa."""
+        return convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @fitparam(
         param_name="lee_mie_radius",
@@ -158,9 +184,9 @@ class LeeMieContribution(Contribution):
         return self._mie_radius
 
     @mieRadius.setter
-    def mieRadius(self, value: float) -> None:  # noqa: N802
+    def mieRadius(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Particle radius in um."""
-        self._mie_radius = value
+        self._mie_radius = self._normalize_radius(value)
 
     @fitparam(
         param_name="lee_mie_q",
@@ -174,8 +200,8 @@ class LeeMieContribution(Contribution):
         return self._mie_q
 
     @mieQ.setter
-    def mieQ(self, value: float) -> None:  # noqa: N802
-        self._mie_q = value
+    def mieQ(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
+        self._mie_q = self._normalize_dimensionless(value)
 
     @fitparam(
         param_name="lee_mie_topP",
@@ -189,9 +215,9 @@ class LeeMieContribution(Contribution):
         return self._mie_top_pressure
 
     @mieTopPressure.setter
-    def mieTopPressure(self, value: float) -> None:  # noqa: N802
+    def mieTopPressure(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Pressure at top of cloud deck in Pa."""
-        self._mie_top_pressure = value
+        self._mie_top_pressure = self._normalize_pressure(value)
 
     @fitparam(
         param_name="lee_mie_bottomP",
@@ -205,9 +231,11 @@ class LeeMieContribution(Contribution):
         return self._mie_bottom_pressure
 
     @mieBottomPressure.setter
-    def mieBottomPressure(self, value: float) -> None:  # noqa: N802
+    def mieBottomPressure(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Pressure at bottom of cloud deck in Pa."""
-        self._mie_bottom_pressure = value
+        self._mie_bottom_pressure = self._normalize_pressure(value)
 
     @fitparam(
         param_name="lee_mie_mix_ratio",
@@ -217,13 +245,13 @@ class LeeMieContribution(Contribution):
         default_bounds=[1e-40, 1],
     )
     def mieMixing(self) -> float:  # noqa: N802
-        """Mixing ratio in atmosphere."""
+        """Particle number density in m^-3."""
         return self._mie_mix
 
     @mieMixing.setter
-    def mieMixing(self, value: float) -> None:  # noqa: N802
-        """Mixing ratio in atmosphere."""
-        self._mie_mix = value
+    def mieMixing(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
+        """Particle number density in m^-3."""
+        self._mie_mix = self._normalize_number_density(value)
 
     def prepare_each(
         self, model: OneDForwardModel, wngrid: npt.NDArray[np.float64]

--- a/src/taurex/contributions/pymiescatt_grid.py
+++ b/src/taurex/contributions/pymiescatt_grid.py
@@ -6,6 +6,7 @@ import h5py
 import numpy as np
 import numpy.typing as npt
 import scipy.stats as stats
+from astropy import units as u
 
 from taurex.cache import GlobalCache
 from taurex.exceptions import InvalidModelException
@@ -14,6 +15,7 @@ from taurex.mpi import has_mpi
 from taurex.mpi import shared_rank
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .contribution import Contribution
 
@@ -214,48 +216,65 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 "At least one species must be provided"
             )
 
+        mean_radius = (
+            self._default_mean_radius
+            if mie_particle_mean_radius is None
+            else mie_particle_mean_radius
+        )
         self._mie_species_path = _broadcast_param(
             mie_species_path, self._species_count, "mie_species_path"
         )
         self._mie_particle_mean_radius = _broadcast_param(
-            mie_particle_mean_radius or self._default_mean_radius,
+            self._normalize_radius(mean_radius),
             self._species_count,
             "mie_particle_mean_radius",
         )
         self._mie_particle_std_radius = _broadcast_param(
-            mie_particle_logstd_radius,
+            self._normalize_dimensionless(mie_particle_logstd_radius),
             self._species_count,
             "mie_particle_logstd_radius",
         )
         self._mie_particle_param_a = _broadcast_param(
-            mie_particle_param_a, self._species_count, "mie_particle_param_a"
+            self._normalize_dimensionless(mie_particle_param_a),
+            self._species_count,
+            "mie_particle_param_a",
         )
         self._mie_particle_param_b = _broadcast_param(
-            mie_particle_param_b, self._species_count, "mie_particle_param_b"
+            self._normalize_dimensionless(mie_particle_param_b),
+            self._species_count,
+            "mie_particle_param_b",
         )
         self._mie_particle_param_c = _broadcast_param(
-            mie_particle_param_c, self._species_count, "mie_particle_param_c"
+            self._normalize_dimensionless(mie_particle_param_c),
+            self._species_count,
+            "mie_particle_param_c",
         )
         self._mie_particle_param_d = _broadcast_param(
-            mie_particle_param_d, self._species_count, "mie_particle_param_d"
+            self._normalize_dimensionless(mie_particle_param_d),
+            self._species_count,
+            "mie_particle_param_d",
         )
         self._mie_particle_mix_ratio = _broadcast_param(
-            mie_particle_mix_ratio,
+            self._normalize_number_density(mie_particle_mix_ratio),
             self._species_count,
             "mie_particle_mix_ratio",
         )
         self._mie_porosity = _broadcast_param(
-            mie_porosity,
+            self._normalize_dimensionless(mie_porosity),
             self._species_count,
             "mie_porosity",
             allow_none=True,
         )
-        self._mie_midP = _broadcast_param(mie_midP, self._species_count, "mie_midP")
+        self._mie_midP = _broadcast_param(
+            self._normalize_pressure(mie_midP), self._species_count, "mie_midP"
+        )
         self._mie_rangeP = _broadcast_param(
-            mie_rangeP, self._species_count, "mie_rangeP"
+            self._normalize_dimensionless(mie_rangeP),
+            self._species_count,
+            "mie_rangeP",
         )
         self._particle_alt_decay = _broadcast_param(
-            mie_particle_altitude_decay,
+            self._normalize_dimensionless(mie_particle_altitude_decay),
             self._species_count,
             "mie_particle_altitude_decay",
         )
@@ -264,10 +283,12 @@ class PyMieScattGridExtinctionContribution(Contribution):
             mie_particle_radius_distribution.lower().strip()
         )
         self._particle_alt_distib = mie_particle_altitude_distrib.lower().strip()
-        self._mie_nMedium = mie_nMedium
-        self._resolution = mie_resolution
-        self._nsampling = int(mie_particle_radius_nsampling)
-        self._dsampling = mie_particle_radius_dsampling
+        self._mie_nMedium = self._normalize_dimensionless(mie_nMedium)
+        self._resolution = int(self._normalize_dimensionless(mie_resolution))
+        self._nsampling = int(
+            self._normalize_dimensionless(mie_particle_radius_nsampling)
+        )
+        self._dsampling = self._normalize_dimensionless(mie_particle_radius_dsampling)
 
         if self._mie_particle_radius_distribution not in {
             "normal",
@@ -288,6 +309,30 @@ class PyMieScattGridExtinctionContribution(Contribution):
             self._mie_species_path
         )
         self.generate_particle_fitting_params()
+
+    @staticmethod
+    def _normalize_radius(value: t.Any) -> t.Any:
+        """Convert particle radii to plain numeric microns."""
+        return convert_to_unit_value(value, u.um, default_unit=u.um)
+
+    @staticmethod
+    def _normalize_dimensionless(value: t.Any) -> t.Any:
+        """Convert dimensionless quantities to plain numeric form."""
+        return convert_to_unit_value(
+            value,
+            u.dimensionless_unscaled,
+            default_unit=u.dimensionless_unscaled,
+        )
+
+    @staticmethod
+    def _normalize_number_density(value: t.Any) -> t.Any:
+        """Convert particle number densities to plain numeric values in m^-3."""
+        return convert_to_unit_value(value, u.m**-3, default_unit=u.m**-3)
+
+    @staticmethod
+    def _normalize_pressure(value: t.Any) -> t.Any:
+        """Convert pressures to plain numeric values in Pa."""
+        return convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @staticmethod
     def _read_qext_dataset(
@@ -426,7 +471,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
             return np.mean(self._mie_particle_mean_radius)
 
         def write_rmean_share(self, value):
-            self._mie_particle_mean_radius[:] = [value] * len(
+            normalized = self._normalize_radius(value)
+            self._mie_particle_mean_radius[:] = [normalized] * len(
                 self._mie_particle_mean_radius
             )
 
@@ -448,7 +494,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return np.mean(self._mie_particle_std_radius)
 
             def write_rstd_share(self, value):
-                self._mie_particle_std_radius[:] = [value] * len(
+                normalized = self._normalize_dimensionless(value)
+                self._mie_particle_std_radius[:] = [normalized] * len(
                     self._mie_particle_std_radius
                 )
 
@@ -469,7 +516,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
             return np.mean(self._mie_particle_mix_ratio)
 
         def write_x_share(self, value):
-            self._mie_particle_mix_ratio[:] = [value] * len(
+            normalized = self._normalize_number_density(value)
+            self._mie_particle_mix_ratio[:] = [normalized] * len(
                 self._mie_particle_mix_ratio
             )
 
@@ -490,7 +538,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
             return np.mean(self._mie_midP)
 
         def write_midp_share(self, value):
-            self._mie_midP[:] = [value] * len(self._mie_midP)
+            normalized = self._normalize_pressure(value)
+            self._mie_midP[:] = [normalized] * len(self._mie_midP)
 
         self.add_fittable_param(
             param_name,
@@ -509,7 +558,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
             return np.mean(self._mie_rangeP)
 
         def write_rangep_share(self, value):
-            self._mie_rangeP[:] = [value] * len(self._mie_rangeP)
+            normalized = self._normalize_dimensionless(value)
+            self._mie_rangeP[:] = [normalized] * len(self._mie_rangeP)
 
         self.add_fittable_param(
             param_name,
@@ -528,7 +578,8 @@ class PyMieScattGridExtinctionContribution(Contribution):
             return np.mean(self._particle_alt_decay)
 
         def write_decayp_share(self, value):
-            self._particle_alt_decay[:] = [value] * len(self._particle_alt_decay)
+            normalized = self._normalize_dimensionless(value)
+            self._particle_alt_decay[:] = [normalized] * len(self._particle_alt_decay)
 
         self.add_fittable_param(
             param_name,
@@ -548,7 +599,7 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return self._mie_particle_mean_radius[idx]
 
             def write_rmean(self, value, idx=idx):
-                self._mie_particle_mean_radius[idx] = value
+                self._mie_particle_mean_radius[idx] = self._normalize_radius(value)
 
             self.add_fittable_param(
                 param_name,
@@ -568,7 +619,9 @@ class PyMieScattGridExtinctionContribution(Contribution):
                     return self._mie_particle_std_radius[idx]
 
                 def write_rstd(self, value, idx=idx):
-                    self._mie_particle_std_radius[idx] = value
+                    self._mie_particle_std_radius[idx] = self._normalize_dimensionless(
+                        value
+                    )
 
                 self.add_fittable_param(
                     param_name,
@@ -588,7 +641,7 @@ class PyMieScattGridExtinctionContribution(Contribution):
                     return self._mie_porosity[idx]
 
                 def write_poro(self, value, idx=idx):
-                    self._mie_porosity[idx] = value
+                    self._mie_porosity[idx] = self._normalize_dimensionless(value)
 
                 self.add_fittable_param(
                     param_name,
@@ -607,7 +660,9 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return self._mie_particle_mix_ratio[idx]
 
             def write_x(self, value, idx=idx):
-                self._mie_particle_mix_ratio[idx] = value
+                self._mie_particle_mix_ratio[idx] = self._normalize_number_density(
+                    value
+                )
 
             self.add_fittable_param(
                 param_name,
@@ -626,7 +681,7 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return self._mie_midP[idx]
 
             def write_midp(self, value, idx=idx):
-                self._mie_midP[idx] = value
+                self._mie_midP[idx] = self._normalize_pressure(value)
 
             self.add_fittable_param(
                 param_name,
@@ -645,7 +700,7 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return self._mie_rangeP[idx]
 
             def write_rangep(self, value, idx=idx):
-                self._mie_rangeP[idx] = value
+                self._mie_rangeP[idx] = self._normalize_dimensionless(value)
 
             self.add_fittable_param(
                 param_name,
@@ -664,7 +719,7 @@ class PyMieScattGridExtinctionContribution(Contribution):
                 return self._particle_alt_decay[idx]
 
             def write_decayp(self, value, idx=idx):
-                self._particle_alt_decay[idx] = value
+                self._particle_alt_decay[idx] = self._normalize_dimensionless(value)
 
             self.add_fittable_param(
                 param_name,

--- a/src/taurex/contributions/simpleclouds.py
+++ b/src/taurex/contributions/simpleclouds.py
@@ -4,11 +4,13 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.fittable import fitparam
 from taurex.model import OneDForwardModel
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 
 from .contribution import Contribution
 
@@ -31,7 +33,10 @@ class SimpleCloudsContribution(Contribution):
 
     """
 
-    def __init__(self, clouds_pressure: t.Optional[float] = 1e3) -> None:
+    def __init__(
+        self,
+        clouds_pressure: t.Optional[t.Union[float, u.Quantity]] = 1e3,
+    ) -> None:
         """Initialize the cloud model.
 
         Parameters
@@ -42,7 +47,12 @@ class SimpleCloudsContribution(Contribution):
 
         """
         super().__init__("SimpleClouds")
-        self._cloud_pressure = clouds_pressure
+        self._cloud_pressure = self._normalize_pressure(clouds_pressure)
+
+    @staticmethod
+    def _normalize_pressure(value: t.Any) -> t.Any:
+        """Convert pressure to plain numeric values in Pa."""
+        return convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     @property
     def order(self) -> int:
@@ -129,9 +139,9 @@ class SimpleCloudsContribution(Contribution):
         return self._cloud_pressure
 
     @cloudsPressure.setter
-    def cloudsPressure(self, value: float) -> None:  # noqa: N802
+    def cloudsPressure(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Cloud top pressure in Pascal."""
-        self._cloud_pressure = value
+        self._cloud_pressure = self._normalize_pressure(value)
 
     def write(self, output: OutputGroup) -> OutputGroup:
         """Write the cloud pressure to the output.

--- a/src/taurex/data/planet.py
+++ b/src/taurex/data/planet.py
@@ -39,10 +39,10 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         planet_radius: t.Optional[t.Union[float, u.Quantity]] = 1.0,
         planet_sma: t.Optional[t.Union[float, u.Quantity]] = None,
         planet_distance: t.Optional[t.Union[float, u.Quantity]] = 1.0,
-        impact_param: t.Optional[float] = 0.5,
-        orbital_period: t.Optional[float] = 2.0,
-        albedo: t.Optional[float] = 0.3,
-        transit_time: t.Optional[float] = 3000.0,
+        impact_param: t.Optional[t.Union[float, u.Quantity]] = 0.5,
+        orbital_period: t.Optional[t.Union[float, u.Quantity]] = 2.0,
+        albedo: t.Optional[t.Union[float, u.Quantity]] = 0.3,
+        transit_time: t.Optional[t.Union[float, u.Quantity]] = 3000.0,
     ) -> None:
         """Initialise a planet.
 
@@ -60,17 +60,17 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         planet_distance: float or astropy.units.Quantity, optional
             Semi-major axis in AU when unitless (deprecated).
 
-        impact_param: float, optional
-            Impact parameter
+        impact_param: float or astropy.units.Quantity, optional
+            Dimensionless impact parameter.
 
-        orbital_period: float, optional
-            Orbital period in days
+        orbital_period: float or astropy.units.Quantity, optional
+            Orbital period in days when unitless.
 
-        albedo: float, optional
-            Planetary albedo
+        albedo: float or astropy.units.Quantity, optional
+            Dimensionless planetary albedo.
 
-        transit_time: float, optional
-            Transit time in seconds
+        transit_time: float or astropy.units.Quantity, optional
+            Transit time in seconds when unitless.
 
         """
         Logger.__init__(self, "Planet")
@@ -80,10 +80,14 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         self.set_planet_semimajoraxis(
             planet_distance if planet_sma is None else planet_sma
         )
-        self._impact = impact_param
-        self._orbit_period = orbital_period
-        self._albedo = albedo
-        self._transit_time = transit_time
+        self._impact = convert_to_unit_value(impact_param, u.dimensionless_unscaled)
+        self._orbit_period = convert_to_unit_value(
+            orbital_period, u.day, default_unit=u.day
+        )
+        self._albedo = convert_to_unit_value(albedo, u.dimensionless_unscaled)
+        self._transit_time = convert_to_unit_value(
+            transit_time, u.s, default_unit=u.s
+        )
 
     def set_planet_radius(
         self,

--- a/src/taurex/data/planet.py
+++ b/src/taurex/data/planet.py
@@ -85,9 +85,7 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
             orbital_period, u.day, default_unit=u.day
         )
         self._albedo = convert_to_unit_value(albedo, u.dimensionless_unscaled)
-        self._transit_time = convert_to_unit_value(
-            transit_time, u.s, default_unit=u.s
-        )
+        self._transit_time = convert_to_unit_value(transit_time, u.s, default_unit=u.s)
 
     def set_planet_radius(
         self,

--- a/src/taurex/data/planet.py
+++ b/src/taurex/data/planet.py
@@ -204,13 +204,13 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         return self.get_planet_mass(unit="Mjup")
 
     @mass.setter
-    def mass(self, value: float) -> None:
+    def mass(self, value: t.Union[float, u.Quantity]) -> None:
         """Set planet mass in Jupiter mass.
 
         Parameters
         ----------
-        value : float
-            Planet mass in Jupiter mass
+        value : float or astropy.units.Quantity
+            Planet mass in Jupiter mass. A Quantity uses its attached unit.
 
         """
         self.set_planet_mass(value, unit="Mjup")
@@ -226,13 +226,13 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         return self.get_planet_radius(unit="Rjup")
 
     @radius.setter
-    def radius(self, value: float) -> None:
+    def radius(self, value: t.Union[float, u.Quantity]) -> None:
         """Set planet radius in Jupiter radii.
 
         Parameters
         ----------
-        value : float
-            Planet radius in Jupiter radii
+        value : float or astropy.units.Quantity
+            Planet radius in Jupiter radii. A Quantity uses its attached unit.
 
         """
         self.set_planet_radius(value, unit="Rjup")
@@ -294,13 +294,13 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         return self.get_planet_semimajoraxis(unit="AU")
 
     @distance.setter
-    def distance(self, value: float) -> None:
+    def distance(self, value: t.Union[float, u.Quantity]) -> None:
         """Set planet semi major axis from parent star (AU).
 
         Parameters
         ----------
-        value : float
-            Semi-major axis in AU
+        value : float or astropy.units.Quantity
+            Semi-major axis in AU. A Quantity uses its attached unit.
 
         """
         self.set_planet_semimajoraxis(value, unit="AU")
@@ -316,13 +316,13 @@ class BasePlanet(Fittable, Logger, Writeable, Citable):
         return self.get_planet_semimajoraxis(unit="AU")
 
     @semiMajorAxis.setter
-    def semiMajorAxis(self, value: float) -> None:  # noqa: N802
+    def semiMajorAxis(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set planet semi major axis from parent star (AU) (ALIAS).
 
         Parameters
         ----------
-        value : float
-            Semi-major axis in AU
+        value : float or astropy.units.Quantity
+            Semi-major axis in AU. A Quantity uses its attached unit.
 
         """
         self.set_planet_semimajoraxis(value, unit="AU")

--- a/src/taurex/data/profiles/chemistry/chemistry.py
+++ b/src/taurex/data/profiles/chemistry/chemistry.py
@@ -4,6 +4,7 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.cache import GlobalCache
 from taurex.cache import OpacityCache
@@ -16,6 +17,7 @@ from taurex.output import OutputGroup
 from taurex.output.writeable import Writeable
 from taurex.planet import Planet
 from taurex.stellar import Star
+from taurex.util import convert_to_unit_value
 
 
 class Chemistry(Fittable, Logger, Writeable, Citable):
@@ -316,6 +318,24 @@ class Chemistry(Fittable, Logger, Writeable, Citable):
         else:
             raise NotImplementedError
 
+    @property
+    def condensateNumberDensityProfile(  # noqa: N802
+        self,
+    ) -> t.Optional[npt.NDArray[np.float64]]:
+        """Return condensate particle number densities in m^-3.
+
+        Chemistry implementations using number-density representations should
+        return plain numeric profiles with shape ``(ncondensates, nlayers)``.
+        This is deliberately separate from the dimensionless
+        :attr:`condensateMixProfile` representation.
+        """
+        return None
+
+    @staticmethod
+    def normalize_condensate_number_density(value: t.Any) -> t.Any:
+        """Normalize condensate particle number density to plain values in m^-3."""
+        return convert_to_unit_value(value, u.m**-3, default_unit=u.m**-3)
+
     def get_condensate_mix_profile(
         self, condensate_name: str
     ) -> npt.NDArray[np.float64]:
@@ -337,6 +357,19 @@ class Chemistry(Fittable, Logger, Writeable, Citable):
             return self.condensateMixProfile[index]
         else:
             raise KeyError(f"Condensate {condensate_name} not found in chemistry")
+
+    def get_condensate_number_density_profile(
+        self, condensate_name: str
+    ) -> npt.NDArray[np.float64]:
+        """Return one condensate particle number-density profile in m^-3."""
+        if condensate_name not in self.condensates:
+            raise KeyError(f"Condensate {condensate_name} not found in chemistry")
+
+        profiles = self.condensateNumberDensityProfile
+        if profiles is None:
+            raise ValueError("Chemistry does not provide condensate number densities")
+
+        return profiles[self.condensates.index(condensate_name)]
 
     def get_molecular_mass(self, molecule: str) -> float:
         """Returns the molecular mass of a molecule.

--- a/src/taurex/data/profiles/chemistry/gas/arraygas.py
+++ b/src/taurex/data/profiles/chemistry/gas/arraygas.py
@@ -35,7 +35,8 @@ class ArrayGas(Gas):
 
         """
         super().__init__(self.__class__.__name__, molecule_name)
-        mix_ratio_array = mix_ratio_array or [1e-2, 1e-6]
+        if mix_ratio_array is None:
+            mix_ratio_array = [1e-2, 1e-6]
         self._mix_ratio_array = np.asarray(
             self.normalize_dimensionless(mix_ratio_array),
             dtype=np.float64,

--- a/src/taurex/data/profiles/chemistry/gas/arraygas.py
+++ b/src/taurex/data/profiles/chemistry/gas/arraygas.py
@@ -36,7 +36,10 @@ class ArrayGas(Gas):
         """
         super().__init__(self.__class__.__name__, molecule_name)
         mix_ratio_array = mix_ratio_array or [1e-2, 1e-6]
-        self._mix_ratio_array = np.array(mix_ratio_array)
+        self._mix_ratio_array = np.asarray(
+            self.normalize_dimensionless(mix_ratio_array),
+            dtype=np.float64,
+        )
 
     @property
     def mixProfile(self) -> npt.NDArray[np.float64]:  # noqa: N802

--- a/src/taurex/data/profiles/chemistry/gas/constantgas.py
+++ b/src/taurex/data/profiles/chemistry/gas/constantgas.py
@@ -38,7 +38,7 @@ class ConstantGas(Gas):
 
         """
         super().__init__("ConstantGas", molecule_name)
-        self._mix_ratio = mix_ratio
+        self._mix_ratio = self.normalize_dimensionless(mix_ratio)
         self.add_active_gas_param()
 
     @property
@@ -96,7 +96,7 @@ class ConstantGas(Gas):
             return self._mix_ratio
 
         def write_mol(self, value):
-            self._mix_ratio = value
+            self._mix_ratio = self.normalize_dimensionless(value)
 
         read_mol.__doc__ = f"{mol_name} constant mix ratio (VMR)"
 

--- a/src/taurex/data/profiles/chemistry/gas/customgas.py
+++ b/src/taurex/data/profiles/chemistry/gas/customgas.py
@@ -37,7 +37,7 @@ class CustomGas(Gas):
 
         """
         super().__init__("CustomGas", molecule_name)
-        self._mix_ratio = mix_ratio
+        self._mix_ratio = self.normalize_dimensionless(mix_ratio)
         self.add_active_gas_param()
 
     @property
@@ -92,7 +92,7 @@ class CustomGas(Gas):
             return self._mix_ratio
 
         def write_mol(self, value):
-            self._mix_ratio = value
+            self._mix_ratio = self.normalize_dimensionless(value)
 
         read_mol.__doc__ = f"{mol_name} custom mix ratio (VMR)"
 

--- a/src/taurex/data/profiles/chemistry/gas/gas.py
+++ b/src/taurex/data/profiles/chemistry/gas/gas.py
@@ -4,12 +4,14 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.data.citation import Citable
 from taurex.data.fittable import Fittable
 from taurex.log import Logger
 from taurex.output import OutputGroup
 from taurex.output.writeable import Writeable
+from taurex.util import convert_to_unit_value
 
 
 class Gas(Fittable, Logger, Writeable, Citable):
@@ -96,6 +98,20 @@ class Gas(Fittable, Logger, Writeable, Citable):
 
         """
         pass
+
+    @staticmethod
+    def normalize_dimensionless(value: t.Union[float, u.Quantity]) -> float:
+        """Convert a dimensionless quantity to plain numeric form."""
+        return convert_to_unit_value(
+            value,
+            u.dimensionless_unscaled,
+            default_unit=u.dimensionless_unscaled,
+        )
+
+    @staticmethod
+    def normalize_pressure(value: t.Union[float, u.Quantity]) -> float:
+        """Convert a pressure-like quantity to Pascals."""
+        return convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
 
     def write(self, output: OutputGroup) -> OutputGroup:
         """Writes class and arguments to file.

--- a/src/taurex/data/profiles/chemistry/gas/powergas.py
+++ b/src/taurex/data/profiles/chemistry/gas/powergas.py
@@ -144,7 +144,7 @@ class PowerGas(Gas):
             return self._mix_surface
 
         def write_surf(self, value):
-            self._mix_surface = value
+            self._mix_surface = self.normalize_dimensionless(value)
 
         fget_surf = read_surf
         fset_surf = write_surf

--- a/src/taurex/data/profiles/chemistry/gas/powergas.py
+++ b/src/taurex/data/profiles/chemistry/gas/powergas.py
@@ -77,7 +77,7 @@ class PowerGas(Gas):
         else:
             self._profile_type = profile_type
 
-        self._mix_surface = mix_ratio_surface
+        self._mix_surface = self.normalize_dimensionless(mix_ratio_surface)
         self._alpha = alpha
         self._beta = beta
         self._gamma = gamma
@@ -115,7 +115,7 @@ class PowerGas(Gas):
     @mixRatioSurface.setter
     def mixRatioSurface(self, value: float):  # noqa: N802
         """Set the abundance on the planets surface."""
-        self._mix_surface = value
+        self._mix_surface = self.normalize_dimensionless(value)
 
     @alpha.setter
     def alpha(self, value: float):

--- a/src/taurex/data/profiles/chemistry/gas/twolayergas.py
+++ b/src/taurex/data/profiles/chemistry/gas/twolayergas.py
@@ -133,7 +133,7 @@ class TwoLayerGas(Gas):
             return self._mix_surface
 
         def write_surf(self, value):
-            self._mix_surface = value
+            self._mix_surface = self.normalize_dimensionless(value)
 
         read_surf.__doc__ = (
             f"Mixing ratio at the surface of the planet for {param_name}"
@@ -170,7 +170,7 @@ class TwoLayerGas(Gas):
             return self._mix_top
 
         def write_top(self, value):
-            self._mix_top = value
+            self._mix_top = self.normalize_dimensionless(value)
 
         read_top.__doc__ = f"Mixing ratio at the top of the atmosphere for {param_name}"
 
@@ -205,7 +205,7 @@ class TwoLayerGas(Gas):
             return self._mix_ratio_pressure
 
         def write_p(self: "TwoLayerGas", value: float):
-            self._mix_ratio_pressure = value
+            self._mix_ratio_pressure = self.normalize_pressure(value)
 
         read_p.__doc__ = f"Pressure at which the mixing ratio changes for {mol_name}"
 

--- a/src/taurex/data/profiles/chemistry/gas/twolayergas.py
+++ b/src/taurex/data/profiles/chemistry/gas/twolayergas.py
@@ -54,9 +54,9 @@ class TwoLayerGas(Gas):
         if mix_ratio_smoothing <= 0:
             raise ValueError("Smoothing window must be positive")
 
-        self._mix_surface = mix_ratio_surface or 1e-4
-        self._mix_top = mix_ratio_top
-        self._mix_ratio_pressure = mix_ratio_P
+        self._mix_surface = self.normalize_dimensionless(mix_ratio_surface or 1e-4)
+        self._mix_top = self.normalize_dimensionless(mix_ratio_top)
+        self._mix_ratio_pressure = self.normalize_pressure(mix_ratio_P)
         self._mix_ratio_smoothing = mix_ratio_smoothing
         self._mix_profile = None
         self.add_surface_param()
@@ -98,17 +98,17 @@ class TwoLayerGas(Gas):
     @mixRatioSurface.setter
     def mixRatioSurface(self, value: float) -> None:  # noqa: N802
         """Set abundance on the planets surface."""
-        self._mix_surface = value
+        self._mix_surface = self.normalize_dimensionless(value)
 
     @mixRatioTop.setter
     def mixRatioTop(self, value: float) -> None:  # noqa: N802
         """Set abundance on the top of atmosphere."""
-        self._mix_top = value
+        self._mix_top = self.normalize_dimensionless(value)
 
     @mixRatioPressure.setter
     def mixRatioPressure(self, value: float) -> None:  # noqa: N802
         """Set pressure at which the abundance changes."""
-        self._mix_ratio_pressure = value
+        self._mix_ratio_pressure = self.normalize_pressure(value)
 
     @mixRatioSmoothing.setter
     def mixRatioSmoothing(self, value: float) -> None:  # noqa: N802

--- a/src/taurex/data/profiles/chemistry/gas/twopointgas.py
+++ b/src/taurex/data/profiles/chemistry/gas/twopointgas.py
@@ -100,7 +100,7 @@ class TwoPointGas(Gas):
             return self._mix_surface
 
         def write_surf(self, value):
-            self._mix_surface = value
+            self._mix_surface = self.normalize_dimensionless(value)
 
         read_surf.__doc__ = f"Abundance of {param_name} on the planets surface"
 
@@ -137,7 +137,7 @@ class TwoPointGas(Gas):
             return self._mix_top
 
         def write_top(self, value):
-            self._mix_top = value
+            self._mix_top = self.normalize_dimensionless(value)
 
         read_top.__doc__ = f"Abundance of {param_name} on the top of atmosphere"
 

--- a/src/taurex/data/profiles/chemistry/gas/twopointgas.py
+++ b/src/taurex/data/profiles/chemistry/gas/twopointgas.py
@@ -43,8 +43,8 @@ class TwoPointGas(Gas):
 
         """
         super().__init__("TwoPointGas", molecule_name)
-        self._mix_surface = mix_ratio_surface
-        self._mix_top = mix_ratio_top
+        self._mix_surface = self.normalize_dimensionless(mix_ratio_surface)
+        self._mix_top = self.normalize_dimensionless(mix_ratio_top)
         self.add_surface_param()
         self.add_top_param()
         self._mix_profile = None
@@ -73,12 +73,12 @@ class TwoPointGas(Gas):
     @mixRatioSurface.setter
     def mixRatioSurface(self, value: float) -> None:  # noqa: N802
         """Set abundance on the planets surface."""
-        self._mix_surface = value
+        self._mix_surface = self.normalize_dimensionless(value)
 
     @mixRatioTop.setter
     def mixRatioTop(self, value: float) -> None:  # noqa: N802
         """Set abundance on the top of atmosphere."""
-        self._mix_top = value
+        self._mix_top = self.normalize_dimensionless(value)
 
     def add_surface_param(self) -> None:
         """Add surface parameter.

--- a/src/taurex/data/profiles/chemistry/taurexchemistry.py
+++ b/src/taurex/data/profiles/chemistry/taurexchemistry.py
@@ -4,12 +4,14 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.core import FittingType
 from taurex.core import derivedparam
 from taurex.exceptions import InvalidModelException
 from taurex.output import OutputGroup
 from taurex.types import get_float_dtype
+from taurex.util import convert_to_unit_value
 from taurex.util import has_duplicates
 from taurex.util import molecule_texlabel
 
@@ -67,9 +69,9 @@ class TaurexChemistry(AutoChemistry):
     def __init__(
         self,
         fill_gases: t.Optional[t.List[str]] = None,
-        ratio: t.Union[float, t.List[float]] = 0.17567,
+        ratio: t.Union[float, t.List[float], u.Quantity] = 0.17567,
         derived_ratios: t.List[str] = None,
-        base_metallicity: float = 0.013,
+        base_metallicity: t.Union[float, u.Quantity] = 0.013,
     ) -> None:
         """Initialize free chemistry.
 
@@ -79,7 +81,7 @@ class TaurexChemistry(AutoChemistry):
             Either a single gas or list of gases to fill the atmosphere with
             default: ``['H2','He']``
 
-        ratio : float or :obj:`list`
+        ratio : float, :obj:`list`, or astropy.units.Quantity
             If a bunch of molecules are used to fill an atmosphere, whats the
             ratio between them?
             The first fill gas is considered the main one with others defined
@@ -91,7 +93,7 @@ class TaurexChemistry(AutoChemistry):
             List of element ratios to compute as derived parameters
             (e.g. ``C/O``)
 
-        base_metallicity : float
+        base_metallicity : float or astropy.units.Quantity
             What to consider the base metallicity of the atmosphere
             (default: 0.013)
 
@@ -106,8 +108,11 @@ class TaurexChemistry(AutoChemistry):
         if isinstance(fill_gases, str):
             fill_gases = [fill_gases]
 
-        if isinstance(ratio, float):
-            ratio = [ratio]
+        ratio = convert_to_unit_value(ratio, u.dimensionless_unscaled)
+        ratio = np.atleast_1d(ratio).tolist()
+        base_metallicity = convert_to_unit_value(
+            base_metallicity, u.dimensionless_unscaled
+        )
 
         if has_duplicates(fill_gases):
             self.error("Fill gasses has duplicate molecules")
@@ -156,7 +161,9 @@ class TaurexChemistry(AutoChemistry):
                 return self._fill_ratio[idx]
 
             def write_mol(self, value, idx=idx):
-                self._fill_ratio[idx] = value
+                self._fill_ratio[idx] = convert_to_unit_value(
+                    value, u.dimensionless_unscaled
+                )
 
             fget = read_mol
             fset = write_mol

--- a/src/taurex/data/profiles/temperature/guillot.py
+++ b/src/taurex/data/profiles/temperature/guillot.py
@@ -25,10 +25,10 @@ class Guillot2010(TemperatureProfile):
     def __init__(
         self,
         T_irr: t.Optional[t.Union[float, u.Quantity]] = 1500,  # noqa: N803
-        kappa_irr: t.Optional[float] = 0.01,
-        kappa_v1: t.Optional[float] = 0.005,
-        kappa_v2: t.Optional[float] = 0.005,
-        alpha: t.Optional[float] = 0.5,
+        kappa_irr: t.Optional[t.Union[float, u.Quantity]] = 0.01,
+        kappa_v1: t.Optional[t.Union[float, u.Quantity]] = 0.005,
+        kappa_v2: t.Optional[t.Union[float, u.Quantity]] = 0.005,
+        alpha: t.Optional[t.Union[float, u.Quantity]] = 0.5,
         T_int: t.Optional[t.Union[float, u.Quantity]] = 100,  # noqa: N803
     ):
         """Initialize guillot temperature profile.
@@ -38,14 +38,15 @@ class Guillot2010(TemperatureProfile):
         T_irr: float or astropy.units.Quantity
             Planet equilibrium temperature in K when unitless.
             (Line fixes this but we keep as free parameter)
-        kappa_irr: float
-            mean infra-red opacity
-        kappa_v1: float
-            mean optical opacity one
-        kappa_v2: float
-            mean optical opacity two
-        alpha: float
-            ratio between kappa_v1 and kappa_v2 downwards radiation stream
+        kappa_irr: float or astropy.units.Quantity
+            Mean infra-red opacity in m^2/kg when unitless.
+        kappa_v1: float or astropy.units.Quantity
+            Mean optical opacity one in m^2/kg when unitless.
+        kappa_v2: float or astropy.units.Quantity
+            Mean optical opacity two in m^2/kg when unitless.
+        alpha: float or astropy.units.Quantity
+            Dimensionless ratio between kappa_v1 and kappa_v2 downwards
+            radiation stream.
         T_int: float or astropy.units.Quantity
             Internal heating parameter in K when unitless.
 
@@ -54,10 +55,10 @@ class Guillot2010(TemperatureProfile):
 
         self.equilTemperature = T_irr
 
-        self.kappa_ir = kappa_irr
-        self.kappa_v1 = kappa_v1
-        self.kappa_v2 = kappa_v2
-        self.alpha = alpha
+        self.meanInfraOpacity = kappa_irr
+        self.meanOpticalOpacity1 = kappa_v1
+        self.meanOpticalOpacity2 = kappa_v2
+        self.opticalRatio = alpha
         self.internalTemperature = T_int
         self._check_values()
 
@@ -97,16 +98,20 @@ class Guillot2010(TemperatureProfile):
         return self.kappa_ir
 
     @meanInfraOpacity.setter
-    def meanInfraOpacity(self, value: float) -> None:  # noqa: N802
+    def meanInfraOpacity(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set mean infra-red opacity.
 
         Parameters
         ----------
-        value : float
-            Mean infra-red opacity.
+        value : float or astropy.units.Quantity
+            Mean infra-red opacity in m^2/kg when unitless.
 
         """
-        self.kappa_ir = value
+        self.kappa_ir = convert_to_unit_value(
+            value, u.m**2 / u.kg, default_unit=u.m**2 / u.kg
+        )
 
     @fitparam(
         param_name="kappa_v1",
@@ -120,16 +125,20 @@ class Guillot2010(TemperatureProfile):
         return self.kappa_v1
 
     @meanOpticalOpacity1.setter
-    def meanOpticalOpacity1(self, value: float) -> None:  # noqa: N802
+    def meanOpticalOpacity1(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set mean optical opacity one.
 
         Parameters
         ----------
-        value : float
-            Mean optical opacity one.
+        value : float or astropy.units.Quantity
+            Mean optical opacity one in m^2/kg when unitless.
 
         """
-        self.kappa_v1 = value
+        self.kappa_v1 = convert_to_unit_value(
+            value, u.m**2 / u.kg, default_unit=u.m**2 / u.kg
+        )
 
     @fitparam(
         param_name="kappa_v2",
@@ -143,16 +152,20 @@ class Guillot2010(TemperatureProfile):
         return self.kappa_v2
 
     @meanOpticalOpacity2.setter
-    def meanOpticalOpacity2(self, value: float) -> None:  # noqa: N802
+    def meanOpticalOpacity2(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set mean optical opacity two.
 
         Parameters
         ----------
-        value : float
-            Mean optical opacity two.
+        value : float or astropy.units.Quantity
+            Mean optical opacity two in m^2/kg when unitless.
 
         """
-        self.kappa_v2 = value
+        self.kappa_v2 = convert_to_unit_value(
+            value, u.m**2 / u.kg, default_unit=u.m**2 / u.kg
+        )
 
     @fitparam(
         param_name="alpha",
@@ -165,16 +178,18 @@ class Guillot2010(TemperatureProfile):
         return self.alpha
 
     @opticalRatio.setter
-    def opticalRatio(self, value: float) -> None:  # noqa: N802
+    def opticalRatio(  # noqa: N802
+        self, value: t.Union[float, u.Quantity]
+    ) -> None:
         """Set ratio between kappa_v1 and kappa_v2.
 
         Parameters
         ----------
-        value : float
-            Ratio between kappa_v1 and kappa_v2.
+        value : float or astropy.units.Quantity
+            Dimensionless ratio between kappa_v1 and kappa_v2.
 
         """
-        self.alpha = value
+        self.alpha = convert_to_unit_value(value, u.dimensionless_unscaled)
 
     @fitparam(
         param_name="T_int_guillot",

--- a/src/taurex/data/profiles/temperature/guillot.py
+++ b/src/taurex/data/profiles/temperature/guillot.py
@@ -98,9 +98,7 @@ class Guillot2010(TemperatureProfile):
         return self.kappa_ir
 
     @meanInfraOpacity.setter
-    def meanInfraOpacity(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def meanInfraOpacity(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set mean infra-red opacity.
 
         Parameters
@@ -178,9 +176,7 @@ class Guillot2010(TemperatureProfile):
         return self.alpha
 
     @opticalRatio.setter
-    def opticalRatio(  # noqa: N802
-        self, value: t.Union[float, u.Quantity]
-    ) -> None:
+    def opticalRatio(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set ratio between kappa_v1 and kappa_v2.
 
         Parameters

--- a/src/taurex/data/stellar/phoenix.py
+++ b/src/taurex/data/stellar/phoenix.py
@@ -7,11 +7,12 @@ import warnings
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.cache import GlobalCache
-from taurex.constants import MSOL
 from taurex.output import OutputGroup
 from taurex.types import PathLike
+from taurex.util import convert_to_unit_value
 
 from .star import BlackbodyStar
 
@@ -28,20 +29,20 @@ class PhoenixStar(BlackbodyStar):
     phoenix_path: str, **required**
         Path to folder containing phoenix ``fits.gz`` files
 
-    temperature: float, optional
-        Stellar temperature in Kelvin
+    temperature: float or astropy.units.Quantity, optional
+        Stellar temperature in K when unitless.
 
-    radius: float, optional
-        Stellar radius in Solar radius
+    radius: float or astropy.units.Quantity, optional
+        Stellar radius in Solar radii when unitless.
 
     metallicity: float, optional
         Metallicity in solar values
 
-    mass: float, optional
-        Stellar mass in solar mass
+    mass: float or astropy.units.Quantity, optional
+        Stellar mass in Solar masses when unitless.
 
-    distance: float, optional
-        Distance from Earth in pc
+    distance: float or astropy.units.Quantity, optional
+        Distance from Earth in pc when unitless.
 
     magnitudeK: float, optional
         Maginitude in K band
@@ -57,11 +58,11 @@ class PhoenixStar(BlackbodyStar):
 
     def __init__(
         self,
-        temperature: t.Optional[float] = 5000,
-        radius: t.Optional[float] = 1.0,
-        metallicity: t.Optional[float] = 1.0,
-        mass: t.Optional[float] = 1.0,
-        distance: t.Optional[float] = 1,
+        temperature: t.Optional[t.Union[float, u.Quantity]] = 5000,
+        radius: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        metallicity: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        mass: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        distance: t.Optional[t.Union[float, u.Quantity]] = 1,
         magnitudeK: t.Optional[float] = 10.0,  # noqa: N803
         phoenix_path: t.Optional[PathLike] = None,
         retro_version_file: t.Optional[PathLike] = None,
@@ -181,9 +182,9 @@ class PhoenixStar(BlackbodyStar):
         return self._temperature
 
     @temperature.setter
-    def temperature(self, value: float) -> None:
+    def temperature(self, value: t.Union[float, u.Quantity]) -> None:
         """Set temperature."""
-        self._temperature = value
+        self._temperature = self._normalize_temperature(value)
         self.recompute_spectra()
 
     @property
@@ -198,9 +199,9 @@ class PhoenixStar(BlackbodyStar):
         return self._mass
 
     @mass.setter
-    def mass(self, value: float) -> None:
+    def mass(self, value: t.Union[float, u.Quantity]) -> None:
         """Set mass."""
-        self._mass = value * MSOL
+        self._mass = convert_to_unit_value(value, u.kg, default_unit=u.M_sun)
         self.recompute_spectra()
 
     def find_nearest_file(self) -> str:

--- a/src/taurex/data/stellar/star.py
+++ b/src/taurex/data/stellar/star.py
@@ -4,6 +4,7 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.constants import MSOL
 from taurex.constants import RSOL
@@ -12,6 +13,7 @@ from taurex.data.fittable import fitparam
 from taurex.log import Logger
 from taurex.output import OutputGroup
 from taurex.output import Writeable
+from taurex.util import convert_to_unit_value
 from taurex.util.emission import black_body
 
 from ..citation import Citable
@@ -26,31 +28,31 @@ class Star(Fittable, Logger, Writeable, Citable):
 
     def __init__(
         self,
-        temperature: t.Optional[float] = 5000,
-        radius: t.Optional[float] = 1.0,
-        distance: t.Optional[float] = 1,
+        temperature: t.Optional[t.Union[float, u.Quantity]] = 5000,
+        radius: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        distance: t.Optional[t.Union[float, u.Quantity]] = 1,
         magnitudeK: t.Optional[float] = 10.0,  # noqa: N803
-        mass: t.Optional[float] = 1.0,
-        metallicity: t.Optional[float] = 1.0,
+        mass: t.Optional[t.Union[float, u.Quantity]] = 1.0,
+        metallicity: t.Optional[t.Union[float, u.Quantity]] = 1.0,
     ):
         """Initialize a star.
 
         Parameters
         ----------
-        temperature: float, optional
-            Stellar temperature in Kelvin
+        temperature: float or astropy.units.Quantity, optional
+            Stellar temperature in K when unitless.
 
-        radius: float, optional
-            Stellar radius in Solar radius
+        radius: float or astropy.units.Quantity, optional
+            Stellar radius in Solar radii when unitless.
 
-        metallicity: float, optional
-            Metallicity in solar values
+        metallicity: float or astropy.units.Quantity, optional
+            Metallicity in solar values when unitless.
 
-        mass: float, optional
-            Stellar mass in solar mass
+        mass: float or astropy.units.Quantity, optional
+            Stellar mass in Solar masses when unitless.
 
-        distance: float, optional
-            Distance from Earth in pc
+        distance: float or astropy.units.Quantity, optional
+            Distance from Earth in pc when unitless.
 
         magnitudeK: float, optional
             Maginitude in K band
@@ -58,14 +60,35 @@ class Star(Fittable, Logger, Writeable, Citable):
         """
         Logger.__init__(self, self.__class__.__name__)
         Fittable.__init__(self)
-        self._temperature = temperature
-        self._radius = radius * RSOL
-        self._mass = mass * MSOL
+        self._temperature = self._normalize_temperature(temperature)
+        self._radius = convert_to_unit_value(radius, u.m, default_unit=u.R_sun)
+        self._mass = convert_to_unit_value(mass, u.kg, default_unit=u.M_sun)
         self.debug("Star mass %s", self._mass)
         self.sed = None
-        self.distance = distance
+        self.distance = self._normalize_distance(distance)
         self.magnitudeK = magnitudeK
-        self._metallicity = metallicity
+        self._metallicity = self._normalize_dimensionless(metallicity)
+
+    @staticmethod
+    def _normalize_temperature(value: t.Union[float, u.Quantity]) -> float:
+        """Convert temperature to plain numeric values in K."""
+        return convert_to_unit_value(
+            value, u.K, default_unit=u.K, equivalencies=u.temperature()
+        )
+
+    @staticmethod
+    def _normalize_distance(value: t.Union[float, u.Quantity]) -> float:
+        """Convert distance to plain numeric values in pc."""
+        return convert_to_unit_value(value, u.pc, default_unit=u.pc)
+
+    @staticmethod
+    def _normalize_dimensionless(value: t.Union[float, u.Quantity]) -> float:
+        """Convert a dimensionless stellar input to a plain numeric value."""
+        return convert_to_unit_value(
+            value,
+            u.dimensionless_unscaled,
+            default_unit=u.dimensionless_unscaled,
+        )
 
     @property
     def radius(self) -> float:
@@ -78,9 +101,9 @@ class Star(Fittable, Logger, Writeable, Citable):
         return self._temperature
 
     @temperature.setter
-    def temperature(self, value: float) -> None:
+    def temperature(self, value: t.Union[float, u.Quantity]) -> None:
         """Set blackbody temperature in Kelvin."""
-        self._temperature = value
+        self._temperature = self._normalize_temperature(value)
 
     @property
     def mass(self) -> float:
@@ -98,9 +121,9 @@ class Star(Fittable, Logger, Writeable, Citable):
         return self.distance
 
     @distanceSystem.setter
-    def distanceSystem(self, value: float) -> None:  # noqa: N802
+    def distanceSystem(self, value: t.Union[float, u.Quantity]) -> None:  # noqa: N802
         """Set distance from Earth to System (in pc)."""
-        self.distance = value
+        self.distance = self._normalize_distance(value)
 
     def initialize(self, wngrid: npt.NDArray[np.float64]) -> None:
         """Initializes the blackbody spectrum on the given wavenumber grid.

--- a/src/taurex/model/emission.py
+++ b/src/taurex/model/emission.py
@@ -309,6 +309,8 @@ class EmissionModel(OneDForwardModel):
         """
         from taurex.util import clip_native_to_wngrid
 
+        wngrid = self._normalize_wngrid(wngrid)
+
         self.initialize_profiles()
 
         native_grid = self.nativeWavenumberGrid

--- a/src/taurex/model/multimodel.py
+++ b/src/taurex/model/multimodel.py
@@ -4,6 +4,7 @@ import typing as t
 
 import numpy as np
 import numpy.typing as npt
+from astropy import units as u
 
 from taurex.binning import Binner
 from taurex.chemistry import Chemistry
@@ -18,6 +19,7 @@ from taurex.stellar import BlackbodyStar
 from taurex.stellar import Star
 from taurex.temperature import TemperatureProfile
 from taurex.util import clip_native_to_wngrid
+from taurex.util import convert_to_unit_value
 from taurex.util.emission import black_body
 
 from .directimage import DirectImageModel
@@ -178,10 +180,10 @@ archivePrefix = {arXiv},
         self._pressure_profiles = self._normalize_sequence(
             pressure_profile, region_count, None
         )
-        self._pressure_min = self._normalize_scalar_or_sequence(
+        self._pressure_min = self._normalize_pressure_scalar_or_sequence(
             pressure_min, region_count, 1e-6
         )
-        self._pressure_max = self._normalize_scalar_or_sequence(
+        self._pressure_max = self._normalize_pressure_scalar_or_sequence(
             pressure_max, region_count, 1e6
         )
         self._nlayers = self._normalize_scalar_or_sequence(nlayers, region_count, 100)
@@ -243,6 +245,42 @@ archivePrefix = {arXiv},
         if isinstance(value, (int, float)):
             return [value] * count
         normalized = list(value)
+        if len(normalized) != count:
+            raise ValueError(
+                "Multimodel scalar inputs must match " "the number of regions"
+            )
+        return normalized
+
+    @staticmethod
+    def _normalize_pressure_scalar_or_sequence(
+        value: t.Optional[
+            t.Union[
+                float,
+                int,
+                u.Quantity,
+                t.Sequence[t.Union[float, int, u.Quantity]],
+            ]
+        ],
+        count: int,
+        default: t.Union[int, float],
+    ) -> t.List[float]:
+        """Normalize pressure bounds to plain numeric values in Pa."""
+        if value is None:
+            default_value = convert_to_unit_value(default, u.Pa, default_unit=u.Pa)
+            return [float(default_value)] * count
+
+        if isinstance(value, (int, float)):
+            converted = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
+            return [float(converted)] * count
+
+        if isinstance(value, u.Quantity):
+            converted = convert_to_unit_value(value, u.Pa, default_unit=u.Pa)
+            return [float(converted)] * count
+
+        normalized = [
+            float(convert_to_unit_value(item, u.Pa, default_unit=u.Pa))
+            for item in list(value)
+        ]
         if len(normalized) != count:
             raise ValueError(
                 "Multimodel scalar inputs must match " "the number of regions"

--- a/src/taurex/model/multimodel.py
+++ b/src/taurex/model/multimodel.py
@@ -602,6 +602,11 @@ archivePrefix = {arXiv},
         t.Optional[t.Any],
     ]:
         """Run model."""
+        if wngrid is not None:
+            wngrid = np.asarray(
+                convert_to_unit_value(wngrid, u.k, equivalencies=u.spectral())
+            )
+
         native_grid = self.nativeWavenumberGrid
         if wngrid is not None and cutoff_grid:
             native_grid = clip_native_to_wngrid(native_grid, wngrid)

--- a/src/taurex/model/simplemodel.py
+++ b/src/taurex/model/simplemodel.py
@@ -414,6 +414,18 @@ class SimpleForwardModel(ForwardModel):
 
         self._native_grid = wngrid
 
+    @staticmethod
+    def _normalize_wngrid(
+        wngrid: t.Optional[t.Union[u.Quantity, npt.NDArray[np.float64]]],
+    ) -> t.Optional[npt.NDArray[np.float64]]:
+        """Normalize a public spectral grid to inverse centimetres."""
+        if wngrid is None:
+            return None
+        return np.asarray(
+            convert_to_unit_value(wngrid, u.k, equivalencies=u.spectral()),
+            dtype=get_float_dtype(),
+        )
+
     def auto_grid(self) -> None:
         """Automatically sets the native grid."""
         self._native_grid = None
@@ -495,6 +507,8 @@ class SimpleForwardModel(ForwardModel):
         extra: ``None``
             Empty
         """
+        wngrid = self._normalize_wngrid(wngrid)
+
         if not self.built:
             self.build()
         # Setup profiles
@@ -547,6 +561,8 @@ class SimpleForwardModel(ForwardModel):
             Dictionary of absorption, tau, and extra for each contribution.
 
         """
+        wngrid = self._normalize_wngrid(wngrid)
+
         # Setup profiles
         self.initialize_profiles()
 
@@ -602,6 +618,8 @@ class SimpleForwardModel(ForwardModel):
         in the atmosphere.
 
         """
+        wngrid = self._normalize_wngrid(wngrid)
+
         native_grid = self.nativeWavenumberGrid
         if wngrid is not None and cutoff_grid:
             native_grid = clip_native_to_wngrid(native_grid, wngrid)

--- a/src/taurex/util/util.py
+++ b/src/taurex/util/util.py
@@ -1020,6 +1020,13 @@ def convert_to_unit_value(
     if isinstance(value, u.Quantity):
         return value.to_value(target_unit, equivalencies=equivalencies or [])
 
+    if isinstance(value, (list, tuple)) and any(
+        isinstance(item, u.Quantity) for item in value
+    ):
+        return u.Quantity(value).to_value(
+            target_unit, equivalencies=equivalencies or []
+        )
+
     if default_unit is None:
         return value
 

--- a/tests/chemistry/test_chemistry.py
+++ b/tests/chemistry/test_chemistry.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import patch
 
+import numpy as np
+import pytest
+from astropy import units as u
 from hypothesis import given
 from hypothesis.strategies import lists
 
@@ -98,3 +101,61 @@ def test_chemistry_active_ktable(mols):
     else:
 
         assert c.availableActive == active_molecules
+
+
+def test_normalize_condensate_number_density_quantity():
+    """Number-density quantities are normalized to plain values in m^-3."""
+    values = Chemistry.normalize_condensate_number_density(
+        np.array([1.0, 2.0]) / u.cm**3
+    )
+
+    np.testing.assert_allclose(values, [1.0e6, 2.0e6])
+    assert not isinstance(values, u.Quantity)
+
+
+def test_normalize_condensate_number_density_preserves_plain_values():
+    """Unitless values retain their existing implicit m^-3 meaning."""
+    values = np.array([1.0, 2.0])
+
+    assert Chemistry.normalize_condensate_number_density(values) is values
+
+
+def test_normalize_condensate_number_density_rejects_mass_density():
+    """Mass density is not silently interpreted as particle number density."""
+    with pytest.raises(u.UnitConversionError):
+        Chemistry.normalize_condensate_number_density(1.0 * u.kg / u.m**3)
+
+
+def test_get_condensate_number_density_profile():
+    """The named accessor selects a profile using the condensate ordering."""
+
+    class NumberDensityChemistry(Chemistry):
+        @property
+        def condensates(self):
+            return ["MgSiO3", "Fe"]
+
+        @property
+        def condensateNumberDensityProfile(self):  # noqa: N802
+            return np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    chemistry = object.__new__(NumberDensityChemistry)
+
+    np.testing.assert_allclose(
+        chemistry.get_condensate_number_density_profile("Fe"), [3.0, 4.0]
+    )
+    with pytest.raises(KeyError, match="Unknown"):
+        chemistry.get_condensate_number_density_profile("Unknown")
+
+
+def test_number_density_accessor_rejects_unsupported_representation():
+    """The named accessor reports when chemistry only provides mix profiles."""
+
+    class MixChemistry(Chemistry):
+        @property
+        def condensates(self):
+            return ["MgSiO3"]
+
+    chemistry = object.__new__(MixChemistry)
+
+    with pytest.raises(ValueError, match="does not provide"):
+        chemistry.get_condensate_number_density_profile("MgSiO3")

--- a/tests/chemistry/test_constantgas.py
+++ b/tests/chemistry/test_constantgas.py
@@ -1,6 +1,7 @@
 """Tests for constant gas."""
 
 import numpy as np
+from astropy import units as u
 from hypothesis import given
 from hypothesis.strategies import floats
 from hypothesis.strategies import integers
@@ -39,3 +40,13 @@ def test_constant_gas(molecule, nlayers, new_value):
     cg.initialize_profile(nlayers=nlayers)
     mix_profile = cg.mixProfile
     assert np.all(mix_profile == new_value)
+
+
+def test_constant_gas_quantity_input():
+    """Dimensionless quantities should be normalized to plain numeric VMR data."""
+    cg = ConstantGas("H2O", mix_ratio=5 * u.percent)
+
+    assert not isinstance(cg._mix_ratio, u.Quantity)
+    assert np.isclose(cg._mix_ratio, 0.05)
+    cg.initialize_profile(nlayers=3)
+    assert np.allclose(cg.mixProfile, 0.05)

--- a/tests/chemistry/test_constantgas.py
+++ b/tests/chemistry/test_constantgas.py
@@ -7,6 +7,7 @@ from hypothesis.strategies import floats
 from hypothesis.strategies import integers
 
 from taurex.chemistry import ConstantGas
+from taurex.data.profiles.chemistry.gas.arraygas import ArrayGas
 
 from ..strategies import molecule_vmr
 
@@ -50,3 +51,11 @@ def test_constant_gas_quantity_input():
     assert np.isclose(cg._mix_ratio, 0.05)
     cg.initialize_profile(nlayers=3)
     assert np.allclose(cg.mixProfile, 0.05)
+
+
+def test_array_gas_quantity_sequence_input():
+    """ArrayGas should normalize a sequence of dimensionless quantities."""
+    gas = ArrayGas("H2O", mix_ratio_array=np.array([5, 1]) * u.percent)
+
+    assert not np.any(np.vectorize(lambda x: isinstance(x, u.Quantity))(gas._mix_ratio_array))
+    np.testing.assert_allclose(gas._mix_ratio_array, [0.05, 0.01])

--- a/tests/chemistry/test_constantgas.py
+++ b/tests/chemistry/test_constantgas.py
@@ -54,8 +54,10 @@ def test_constant_gas_quantity_input():
 
 
 def test_array_gas_quantity_sequence_input():
-    """ArrayGas should normalize a sequence of dimensionless quantities."""
+    """Normalize an ArrayGas sequence of dimensionless quantities."""
     gas = ArrayGas("H2O", mix_ratio_array=np.array([5, 1]) * u.percent)
 
-    assert not np.any(np.vectorize(lambda x: isinstance(x, u.Quantity))(gas._mix_ratio_array))
+    assert not np.any(
+        np.vectorize(lambda x: isinstance(x, u.Quantity))(gas._mix_ratio_array)
+    )
     np.testing.assert_allclose(gas._mix_ratio_array, [0.05, 0.01])

--- a/tests/chemistry/test_free_chemistry.py
+++ b/tests/chemistry/test_free_chemistry.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from astropy import units as u
 from hypothesis import given
 from hypothesis import note
 from hypothesis import settings
@@ -39,6 +40,40 @@ def test_fill_gas_pair_ratio(ratio, tp):
     assert computed_ratio[0] == pytest.approx(ratio)
     assert tc.mixProfile.shape[0] == 2
     assert tc.mixProfile.shape[1] == n
+
+
+def test_bulk_chemistry_accepts_dimensionless_quantities():
+    """Fill ratios and base metallicity are stored as plain fractions."""
+    chemistry = TaurexChemistry(
+        fill_gases=["H2", "He", "N2"],
+        ratio=[10.0 * u.percent, 5.0 * u.percent],
+        base_metallicity=1.3 * u.percent,
+    )
+
+    np.testing.assert_allclose(chemistry._fill_ratio, [0.1, 0.05])
+    assert chemistry._base_metallicity == pytest.approx(0.013)
+    assert not any(isinstance(value, u.Quantity) for value in chemistry._fill_ratio)
+    assert not isinstance(chemistry._base_metallicity, u.Quantity)
+
+
+def test_bulk_chemistry_fill_ratio_setter_accepts_quantity():
+    """Generated fitting setters normalize dimensionless quantities."""
+    chemistry = TaurexChemistry()
+
+    chemistry.fitting_parameters()["He_H2"][3](20.0 * u.percent)
+
+    assert chemistry._fill_ratio[0] == pytest.approx(0.2)
+    assert not isinstance(chemistry._fill_ratio[0], u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "quantity"),
+    [("ratio", 1.0 * u.Pa), ("base_metallicity", 1.0 * u.kg)],
+)
+def test_bulk_chemistry_rejects_physical_quantities(parameter, quantity):
+    """Bulk chemistry fractions reject physical dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        TaurexChemistry(**{parameter: quantity})
 
 
 @given(

--- a/tests/chemistry/test_gas_quantities.py
+++ b/tests/chemistry/test_gas_quantities.py
@@ -1,0 +1,70 @@
+"""Tests for unit-aware gas-profile input boundaries."""
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from taurex.chemistry import CustomGas
+from taurex.chemistry import PowerGas
+from taurex.chemistry import TwoLayerGas
+from taurex.chemistry import TwoPointGas
+
+
+@pytest.mark.parametrize(
+    ("gas", "parameter_names"),
+    [
+        (PowerGas("H2O", mix_ratio_surface=1e-4), ("H2O_surface",)),
+        (
+            TwoLayerGas("CH4"),
+            ("CH4_surface", "CH4_top"),
+        ),
+        (TwoPointGas("CO"), ("CO_surface", "CO_top")),
+    ],
+)
+def test_gas_fitting_setters_normalize_dimensionless_quantities(gas, parameter_names):
+    """Dynamic fitting setters should accept dimensionless quantities."""
+    parameters = gas.fitting_parameters()
+
+    for parameter_name in parameter_names:
+        parameters[parameter_name][3](5 * u.percent)
+        assert parameters[parameter_name][2]() == pytest.approx(0.05)
+
+
+def test_two_layer_pressure_fitting_setter_normalizes_quantity():
+    """The dynamic boundary-pressure setter should store Pascals."""
+    gas = TwoLayerGas("CH4")
+    parameter = gas.fitting_parameters()["CH4_P"]
+
+    parameter[3](0.2 * u.bar)
+
+    assert parameter[2]() == pytest.approx(20_000.0)
+
+
+def test_custom_gas_normalizes_quantity_array_and_fitting_setter():
+    """The custom gas should normalize constructor and fitting-setter arrays."""
+    gas = CustomGas("H2O", np.array([5, 1]) * u.percent)
+    gas.initialize_profile(nlayers=2)
+
+    np.testing.assert_allclose(gas.mixProfile, [0.05, 0.01])
+    assert not isinstance(gas.mixProfile, u.Quantity)
+
+    gas.fitting_parameters()["H2O"][3](np.array([2, 1]) * u.percent)
+    gas.initialize_profile(nlayers=2)
+    np.testing.assert_allclose(gas.mixProfile, [0.02, 0.01])
+
+
+@pytest.mark.parametrize(
+    "gas",
+    [
+        CustomGas("H2O", [1e-4]),
+        PowerGas("H2O", mix_ratio_surface=1e-4),
+        TwoLayerGas("CH4"),
+        TwoPointGas("CO"),
+    ],
+)
+def test_gas_quantity_boundaries_reject_physical_units(gas):
+    """VMR inputs should reject quantities with physical dimensions."""
+    parameter_name = next(iter(gas.fitting_parameters()))
+
+    with pytest.raises(u.UnitConversionError):
+        gas.fitting_parameters()[parameter_name][3](1 * u.kg)

--- a/tests/contribution/test_leemie_units.py
+++ b/tests/contribution/test_leemie_units.py
@@ -1,0 +1,76 @@
+"""Tests for unit-aware Lee Mie inputs."""
+
+import pytest
+from astropy import units as u
+
+from taurex.contributions import LeeMieContribution
+
+
+def test_leemie_constructor_normalizes_quantities():
+    """Constructor quantities should be stored in Lee Mie's internal units."""
+    contribution = LeeMieContribution(
+        lee_mie_radius=100 * u.nm,
+        lee_mie_q=40 * u.dimensionless_unscaled,
+        lee_mie_mix_ratio=2 / u.cm**3,
+        lee_mie_bottomP=0.2 * u.bar,
+        lee_mie_topP=1 * u.mbar,
+    )
+
+    assert contribution.mieRadius == pytest.approx(0.1)
+    assert contribution.mieQ == pytest.approx(40.0)
+    assert contribution.mieMixing == pytest.approx(2e6)
+    assert contribution.mieBottomPressure == pytest.approx(20_000.0)
+    assert contribution.mieTopPressure == pytest.approx(100.0)
+    assert not isinstance(contribution.mieRadius, u.Quantity)
+    assert not isinstance(contribution.mieMixing, u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "quantity", "expected"),
+    [
+        ("lee_mie_radius", 0.2 * u.mm, 200.0),
+        ("lee_mie_q", 25 * u.percent, 0.25),
+        ("lee_mie_mix_ratio", 3 / u.cm**3, 3e6),
+        ("lee_mie_bottomP", 0.3 * u.bar, 30_000.0),
+        ("lee_mie_topP", 2 * u.mbar, 200.0),
+    ],
+)
+def test_leemie_fitting_setters_normalize_quantities(
+    parameter_name, quantity, expected
+):
+    """Fitting setters should apply the same conversions as the constructor."""
+    parameter = LeeMieContribution().fitting_parameters()[parameter_name]
+
+    parameter[3](quantity)
+
+    assert parameter[2]() == pytest.approx(expected)
+    assert not isinstance(parameter[2](), u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "quantity"),
+    [
+        ("lee_mie_radius", 1 * u.s),
+        ("lee_mie_q", 1 * u.kg),
+        ("lee_mie_mix_ratio", 1 * u.kg / u.m**3),
+        ("lee_mie_bottomP", 1 * u.m),
+        ("lee_mie_topP", 1 * u.K),
+    ],
+)
+def test_leemie_rejects_incompatible_units(parameter_name, quantity):
+    """Each physical input should reject an incompatible dimension."""
+    parameter = LeeMieContribution().fitting_parameters()[parameter_name]
+
+    with pytest.raises(u.UnitConversionError):
+        parameter[3](quantity)
+
+
+def test_leemie_preserves_legacy_values_and_pressure_sentinels():
+    """Unitless values should retain their existing implicit units."""
+    contribution = LeeMieContribution(0.5, 20, 1e8, -1, -1)
+
+    assert contribution.mieRadius == 0.5
+    assert contribution.mieQ == 20
+    assert contribution.mieMixing == 1e8
+    assert contribution.mieBottomPressure == -1
+    assert contribution.mieTopPressure == -1

--- a/tests/contribution/test_pymiescatt_grid_units.py
+++ b/tests/contribution/test_pymiescatt_grid_units.py
@@ -1,0 +1,122 @@
+"""Tests for unit-aware precomputed-grid Mie inputs."""
+
+import h5py
+import numpy as np
+import pytest
+from astropy import units as u
+
+from taurex.contributions import PyMieScattGridExtinctionContribution
+
+
+@pytest.fixture
+def grid_paths(tmp_path):
+    """Create two minimal extinction grids."""
+    paths = []
+    for index in range(2):
+        path = tmp_path / f"cloud_grid_{index}.h5"
+        with h5py.File(path, "w") as handle:
+            handle.create_dataset("radius_grid", data=[0.05, 0.1, 0.2])
+            handle.create_dataset("wavenumber_grid", data=[1000.0, 2000.0])
+            handle.create_dataset(
+                "Qext",
+                data=np.array([[1.0, 1.5], [1.2, 1.7], [1.5, 2.0]]),
+            )
+        paths.append(str(path))
+    return paths
+
+
+def make_contribution(grid_paths, **kwargs):
+    """Create a two-species contribution for boundary tests."""
+    return PyMieScattGridExtinctionContribution(
+        species=["Mg2SiO4", "SiO2"],
+        mie_species_path=grid_paths,
+        **kwargs,
+    )
+
+
+def test_grid_mie_constructor_normalizes_quantity_arrays(grid_paths):
+    """Constructor quantities should be converted before broadcasting."""
+    contribution = make_contribution(
+        grid_paths,
+        mie_particle_mean_radius=np.array([100, 200]) * u.nm,
+        mie_particle_logstd_radius=5 * u.percent,
+        mie_particle_mix_ratio=np.array([2, 3]) / u.cm**3,
+        mie_porosity=np.array([10, 20]) * u.percent,
+        mie_midP=np.array([0.2, 0.1]) * u.bar,
+        mie_rangeP=np.array([1, 2]) * u.dimensionless_unscaled,
+        mie_nMedium=125 * u.percent,
+        mie_particle_radius_dsampling=200 * u.percent,
+        mie_particle_altitude_decay=-2 * u.dimensionless_unscaled,
+    )
+
+    np.testing.assert_allclose(contribution._mie_particle_mean_radius, [0.1, 0.2])
+    np.testing.assert_allclose(contribution._mie_particle_std_radius, [0.05, 0.05])
+    np.testing.assert_allclose(contribution._mie_particle_mix_ratio, [2e6, 3e6])
+    np.testing.assert_allclose(contribution._mie_porosity, [0.1, 0.2])
+    np.testing.assert_allclose(contribution._mie_midP, [20_000.0, 10_000.0])
+    np.testing.assert_allclose(contribution._mie_rangeP, [1.0, 2.0])
+    np.testing.assert_allclose(contribution._particle_alt_decay, [-2.0, -2.0])
+    assert contribution._mie_nMedium == pytest.approx(1.25)
+    assert contribution._dsampling == pytest.approx(2.0)
+    assert not isinstance(contribution._mie_particle_mix_ratio[0], u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "quantity", "expected"),
+    [
+        ("Rmean_share", 0.2 * u.mm, 200.0),
+        ("Rlogstd_share", 10 * u.percent, 0.1),
+        ("X_share", 4 / u.cm**3, 4e6),
+        ("midP_share", 0.3 * u.bar, 30_000.0),
+        ("rangeP_share", 50 * u.percent, 0.5),
+        ("decayP_share", -200 * u.percent, -2.0),
+        ("Rmean_Mg2SiO4", 300 * u.nm, 0.3),
+        ("Rlogstd_Mg2SiO4", 20 * u.percent, 0.2),
+        ("Porosity_Mg2SiO4", 25 * u.percent, 0.25),
+        ("X_Mg2SiO4", 5 / u.cm**3, 5e6),
+        ("midP_Mg2SiO4", 2 * u.mbar, 200.0),
+        ("rangeP_Mg2SiO4", 150 * u.percent, 1.5),
+        ("decayP_Mg2SiO4", -300 * u.percent, -3.0),
+    ],
+)
+def test_grid_mie_fitting_setters_normalize_quantities(
+    grid_paths, parameter_name, quantity, expected
+):
+    """Shared and per-species setters should normalize quantities."""
+    contribution = make_contribution(grid_paths, mie_porosity=[0.0, 0.0])
+    parameter = contribution.fitting_parameters()[parameter_name]
+
+    parameter[3](quantity)
+
+    assert parameter[2]() == pytest.approx(expected)
+    assert not isinstance(parameter[2](), u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("keyword", "quantity"),
+    [
+        ("mie_particle_mean_radius", 1 * u.s),
+        ("mie_particle_logstd_radius", 1 * u.kg),
+        ("mie_particle_mix_ratio", 1 * u.kg / u.m**3),
+        ("mie_midP", 1 * u.m),
+        ("mie_rangeP", 1 * u.K),
+    ],
+)
+def test_grid_mie_rejects_incompatible_constructor_units(grid_paths, keyword, quantity):
+    """Physical and dimensionless boundaries should reject wrong dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        make_contribution(grid_paths, **{keyword: quantity})
+
+
+def test_grid_mie_preserves_legacy_values(grid_paths):
+    """Unitless inputs should retain their documented implicit units."""
+    contribution = make_contribution(
+        grid_paths,
+        mie_particle_mean_radius=[0.1, 0.2],
+        mie_particle_mix_ratio=[1e8, 2e8],
+        mie_midP=[1e4, -1],
+    )
+
+    assert contribution._mie_particle_mean_radius == [0.1, 0.2]
+    assert contribution._mie_particle_mix_ratio == [1e8, 2e8]
+    assert contribution._mie_midP == [1e4, -1]

--- a/tests/contribution/test_remaining_cloud_units.py
+++ b/tests/contribution/test_remaining_cloud_units.py
@@ -1,0 +1,83 @@
+"""Tests for unit-aware simple and flat cloud inputs."""
+
+import pytest
+from astropy import units as u
+
+from taurex.contributions import FlatMieContribution
+from taurex.contributions import SimpleCloudsContribution
+
+
+def test_simple_clouds_constructor_and_setter_normalize_pressure():
+    """Simple cloud pressure should be stored as a plain value in Pa."""
+    contribution = SimpleCloudsContribution(0.2 * u.bar)
+
+    assert contribution.cloudsPressure == pytest.approx(20_000.0)
+    assert not isinstance(contribution.cloudsPressure, u.Quantity)
+
+    parameter = contribution.fitting_parameters()["clouds_pressure"]
+    parameter[3](3 * u.mbar)
+    assert parameter[2]() == pytest.approx(300.0)
+
+
+def test_flat_mie_constructor_normalizes_quantities():
+    """Flat Mie inputs should be stored in m2 and Pa."""
+    contribution = FlatMieContribution(
+        flat_mix_ratio=2 * u.cm**2,
+        flat_bottomP=0.3 * u.bar,
+        flat_topP=2 * u.mbar,
+    )
+
+    assert contribution.mieMixing == pytest.approx(2e-4)
+    assert contribution.mieBottomPressure == pytest.approx(30_000.0)
+    assert contribution.mieTopPressure == pytest.approx(200.0)
+    assert not isinstance(contribution.mieMixing, u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("parameter_name", "quantity", "expected"),
+    [
+        ("flat_mix_ratio", 3 * u.cm**2, 3e-4),
+        ("flat_bottomP", 0.4 * u.bar, 40_000.0),
+        ("flat_topP", 5 * u.mbar, 500.0),
+    ],
+)
+def test_flat_mie_fitting_setters_normalize_quantities(
+    parameter_name, quantity, expected
+):
+    """Flat Mie fitting setters should match constructor conversions."""
+    parameter = FlatMieContribution().fitting_parameters()[parameter_name]
+
+    parameter[3](quantity)
+
+    assert parameter[2]() == pytest.approx(expected)
+    assert not isinstance(parameter[2](), u.Quantity)
+
+
+@pytest.mark.parametrize(
+    ("contribution", "parameter_name", "quantity"),
+    [
+        (SimpleCloudsContribution(), "clouds_pressure", 1 * u.m),
+        (FlatMieContribution(), "flat_mix_ratio", 1 * u.kg),
+        (FlatMieContribution(), "flat_bottomP", 1 * u.s),
+        (FlatMieContribution(), "flat_topP", 1 * u.K),
+    ],
+)
+def test_remaining_cloud_inputs_reject_incompatible_units(
+    contribution, parameter_name, quantity
+):
+    """Cloud input boundaries should reject incompatible dimensions."""
+    parameter = contribution.fitting_parameters()[parameter_name]
+
+    with pytest.raises(u.UnitConversionError):
+        parameter[3](quantity)
+
+
+def test_remaining_cloud_inputs_preserve_legacy_values_and_sentinels():
+    """Unitless inputs should retain their existing implicit units."""
+    simple = SimpleCloudsContribution(1e4)
+    flat = FlatMieContribution(1e-8, -1, -1)
+
+    assert simple.cloudsPressure == 1e4
+    assert flat.mieMixing == 1e-8
+    assert flat.mieBottomPressure == -1
+    assert flat.mieTopPressure == -1

--- a/tests/model/test_multimodel.py
+++ b/tests/model/test_multimodel.py
@@ -1,5 +1,7 @@
 """Test MultiModel."""
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 from astropy import units as u
@@ -19,6 +21,39 @@ def test_multitransit_pressure_quantity_inputs():
 
     np.testing.assert_allclose(model._pressure_min, [0.1, 0.2])
     np.testing.assert_allclose(model._pressure_max, [1000.0, 2000.0])
+
+
+def test_multitransit_model_normalizes_wavelength_grid():
+    """Composite models pass plain inverse-centimetre grids to submodels."""
+    from taurex.model import MultiTransitModel
+
+    model = object.__new__(MultiTransitModel)
+    model._sub_models = [MagicMock()]
+    model._fractions = [1.0]
+    model._active_chems = [None]
+    model._inactive_chems = [None]
+    model._mus = [None]
+    model._temperatures = [None]
+    model.autofrac = False
+    model.initialize_profiles = MagicMock()
+    model._sub_models[0].nativeWavenumberGrid = np.linspace(4000.0, 11000.0, 8)
+    model._sub_models[0].model.return_value = (
+        np.array([5000.0, 10000.0]),
+        np.ones(2),
+        np.ones(2),
+        None,
+    )
+    chemistry = model._sub_models[0].chemistry
+    chemistry.activeGasMixProfile = np.ones((1, 1))
+    chemistry.inactiveGasMixProfile = np.ones((1, 1))
+    chemistry.muProfile = np.ones(1)
+    model._sub_models[0].temperatureProfile = np.ones(1)
+
+    model.model(np.array([2.0, 1.0]) * u.micron)
+
+    passed_grid = model._sub_models[0].model.call_args.kwargs["wngrid"]
+    np.testing.assert_allclose(passed_grid, np.linspace(4000.0, 11000.0, 8))
+    assert not isinstance(passed_grid, u.Quantity)
 
 
 def test_multitransit_autofraction_completion():

--- a/tests/model/test_multimodel.py
+++ b/tests/model/test_multimodel.py
@@ -1,6 +1,24 @@
 """Test MultiModel."""
 
+import numpy as np
 import pytest
+from astropy import units as u
+
+
+def test_multitransit_pressure_quantity_inputs():
+    """Pressure bounds should accept Quantity values and normalize to Pa."""
+    from taurex.model import MultiTransitModel
+
+    model = MultiTransitModel(
+        temperature_profiles=[None, None],
+        chemistry=[None, None],
+        pressure_min=[1e-6 * u.bar, 2e-6 * u.bar],
+        pressure_max=[1e3 * u.Pa, 2e3 * u.Pa],
+        fractions=[0.5],
+    )
+
+    np.testing.assert_allclose(model._pressure_min, [0.1, 0.2])
+    np.testing.assert_allclose(model._pressure_max, [1000.0, 2000.0])
 
 
 def test_multitransit_autofraction_completion():

--- a/tests/model/test_simplemodel.py
+++ b/tests/model/test_simplemodel.py
@@ -47,3 +47,17 @@ def test_set_native_grid_rejects_incompatible_quantity(model):
     """Quantities that are not spectral coordinates are rejected."""
     with pytest.raises(u.UnitConversionError):
         model.set_native_grid(np.array([1.0, 2.0, 3.0]) * u.kg)
+
+
+def test_normalize_model_wngrid_converts_wavelength_quantity(model):
+    """Public model grids are normalized to inverse centimetres."""
+    normalized = model._normalize_wngrid(np.array([1.0, 2.0]) * u.micron)
+
+    np.testing.assert_allclose(normalized, [10000.0, 5000.0])
+    assert normalized.dtype == get_float_dtype()
+    assert not isinstance(normalized, u.Quantity)
+
+
+def test_normalize_model_wngrid_preserves_none(model):
+    """An omitted model grid continues to select the native grid."""
+    assert model._normalize_wngrid(None) is None

--- a/tests/stellar/test_blackbody.py
+++ b/tests/stellar/test_blackbody.py
@@ -1,11 +1,86 @@
 """Test blackbody star."""
 
+import astropy.units as u
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis import strategies as st
 
 from ..strategies import hyp_wngrid
+
+
+def test_blackbody_preserves_plain_value_units():
+    """Plain constructor values retain their documented legacy units."""
+    from taurex.constants import MSOL
+    from taurex.constants import RSOL
+    from taurex.stellar import BlackbodyStar
+
+    star = BlackbodyStar(
+        temperature=4500,
+        radius=2,
+        distance=3,
+        mass=4,
+        metallicity=0.5,
+    )
+
+    assert star.temperature == pytest.approx(4500)
+    assert star.radius == pytest.approx(2 * RSOL)
+    assert star.mass == pytest.approx(4 * MSOL)
+    assert star.distance == pytest.approx(3)
+    assert star._metallicity == pytest.approx(0.5)
+
+
+def test_blackbody_accepts_quantity_constructor_values():
+    """Quantity constructor values are normalized to internal units."""
+    from taurex.stellar import BlackbodyStar
+
+    star = BlackbodyStar(
+        temperature=25 * u.deg_C,
+        radius=2e6 * u.km,
+        distance=10 * u.lyr,
+        mass=3 * u.M_earth,
+        metallicity=2 * u.percent,
+    )
+
+    assert star.temperature == pytest.approx(
+        (25 * u.deg_C).to_value(u.K, u.temperature())
+    )
+    assert star.radius == pytest.approx((2e6 * u.km).to_value(u.m))
+    assert star.mass == pytest.approx((3 * u.M_earth).to_value(u.kg))
+    assert star.distance == pytest.approx((10 * u.lyr).to_value(u.pc))
+    assert star._metallicity == pytest.approx(0.02)
+
+
+def test_blackbody_quantity_setters():
+    """Public stellar setters normalize quantities to their legacy units."""
+    from taurex.stellar import BlackbodyStar
+
+    star = BlackbodyStar()
+
+    star.temperature = 3000 * u.K
+    star["distance"] = 10 * u.lyr
+
+    assert star.temperature == pytest.approx(3000)
+    assert star.distance == pytest.approx((10 * u.lyr).to_value(u.pc))
+
+
+@pytest.mark.parametrize(
+    ("parameter", "value"),
+    [
+        ("temperature", 1 * u.kg),
+        ("radius", 1 * u.s),
+        ("distance", 1 * u.K),
+        ("mass", 1 * u.m),
+        ("metallicity", 1 * u.Pa),
+    ],
+)
+def test_blackbody_rejects_incompatible_quantities(parameter, value):
+    """Incompatible stellar quantities raise Astropy conversion errors."""
+    from taurex.stellar import BlackbodyStar
+
+    with pytest.raises(u.UnitConversionError):
+        BlackbodyStar(**{parameter: value})
 
 
 @given(

--- a/tests/stellar/test_phoenix.py
+++ b/tests/stellar/test_phoenix.py
@@ -3,7 +3,9 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import astropy.units as u
 import numpy as np
+import pytest
 
 from taurex.stellar import PhoenixStar
 
@@ -62,3 +64,30 @@ def test_phoenix_find_spectrum(tmpdir):
         phoenix._temperature = tp
         phoenix._metallicity = mtl
         assert phoenix.find_nearest_file() == fn
+
+
+def test_phoenix_quantity_inputs_and_setters(tmpdir):
+    """PHOENIX normalizes constructor values and its overridden setters."""
+    with patch.multiple(
+        "taurex.stellar.PhoenixStar",
+        get_avail_phoenix=MagicMock(),
+        recompute_spectra=MagicMock(),
+    ):
+        phoenix = PhoenixStar(
+            temperature=1 * u.kK,
+            radius=1 * u.R_earth,
+            mass=2 * u.M_earth,
+            distance=1 * u.kpc,
+            phoenix_path=str(tmpdir),
+        )
+
+        assert phoenix.temperature == pytest.approx(1000)
+        assert phoenix.radius == pytest.approx(u.R_earth.to(u.m))
+        assert phoenix.mass == pytest.approx((2 * u.M_earth).to_value(u.kg))
+        assert phoenix.distance == pytest.approx(1000)
+
+        phoenix.temperature = 2000 * u.K
+        phoenix.mass = 3 * u.M_earth
+
+        assert phoenix.temperature == pytest.approx(2000)
+        assert phoenix.mass == pytest.approx((3 * u.M_earth).to_value(u.kg))

--- a/tests/temperature/test_guillot.py
+++ b/tests/temperature/test_guillot.py
@@ -172,3 +172,51 @@ def test_guillot_rejects_quantity_below_absolute_zero():
     """Validation occurs after conversion to the internal Kelvin unit."""
     with pytest.raises(InvalidModelException, match="Negative temperature"):
         Guillot2010(T_int=u.Quantity(-300.0, u.deg_C))
+
+
+def test_guillot_accepts_opacity_and_ratio_quantities():
+    """Opacity and ratio inputs are normalized to their internal units."""
+    profile = Guillot2010(
+        kappa_irr=100.0 * u.cm**2 / u.g,
+        kappa_v1=50.0 * u.cm**2 / u.g,
+        kappa_v2=25.0 * u.cm**2 / u.g,
+        alpha=50.0 * u.percent,
+    )
+
+    assert profile.meanInfraOpacity == pytest.approx(10.0)
+    assert profile.meanOpticalOpacity1 == pytest.approx(5.0)
+    assert profile.meanOpticalOpacity2 == pytest.approx(2.5)
+    assert profile.opticalRatio == pytest.approx(0.5)
+    assert not isinstance(profile.kappa_ir, u.Quantity)
+    assert not isinstance(profile.alpha, u.Quantity)
+
+
+def test_guillot_opacity_and_ratio_setters_accept_quantities():
+    """Fittable opacity and ratio setters normalize Quantity values."""
+    profile = Guillot2010()
+    parameters = profile.fitting_parameters()
+
+    parameters["kappa_irr"][3](20.0 * u.cm**2 / u.g)
+    parameters["kappa_v1"][3](30.0 * u.cm**2 / u.g)
+    parameters["kappa_v2"][3](40.0 * u.cm**2 / u.g)
+    parameters["alpha"][3](25.0 * u.percent)
+
+    assert profile.meanInfraOpacity == pytest.approx(2.0)
+    assert profile.meanOpticalOpacity1 == pytest.approx(3.0)
+    assert profile.meanOpticalOpacity2 == pytest.approx(4.0)
+    assert profile.opticalRatio == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "quantity"),
+    [
+        ("kappa_irr", 1.0 * u.K),
+        ("kappa_v1", 1.0 * u.m),
+        ("kappa_v2", 1.0 * u.kg),
+        ("alpha", 1.0 * u.Pa),
+    ],
+)
+def test_guillot_rejects_incompatible_physical_quantities(parameter, quantity):
+    """Opacity and ratio parameters reject incompatible dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        Guillot2010(**{parameter: quantity})

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+from astropy import units as u
 
 from taurex.binning import Binner
 from taurex.binning import FluxBinner
@@ -81,6 +82,51 @@ def test_simplebinner(spectra):
     assert wngrid.shape[0] == wn.shape[0]
 
     assert np.mean(sp) == pytest.approx(np.mean(spectra[1]), rel=0.1)
+
+
+def test_simplebinner_normalizes_spectral_quantities():
+    """The wavenumber grid and widths are stored in inverse centimetres."""
+    binner = SimpleBinner(
+        np.array([2.0, 1.0]) * u.micron,
+        wngrid_width=np.array([20.0, 10.0]) / u.m,
+    )
+
+    np.testing.assert_allclose(binner._wngrid, [5000.0, 10000.0])
+    np.testing.assert_allclose(binner._wn_width, [0.2, 0.1])
+    assert not isinstance(binner._wngrid, u.Quantity)
+    assert not isinstance(binner._wn_width, u.Quantity)
+
+
+def test_simplebinner_rejects_incompatible_quantity():
+    """Non-spectral grid quantities fail at the public boundary."""
+    with pytest.raises(u.UnitConversionError):
+        SimpleBinner(np.array([1.0, 2.0]) * u.kg)
+
+
+def test_fluxbinner_normalizes_wavenumber_quantities():
+    """Wavenumber centers and widths use inverse centimetres internally."""
+    binner = FluxBinner(
+        wngrid=np.array([2.0, 1.0]) / u.m,
+        wngrid_width=np.array([20.0, 10.0]) / u.m,
+    )
+
+    np.testing.assert_allclose(binner._bin_centers, [0.01, 0.02])
+    np.testing.assert_allclose(binner._bin_widths, [0.1, 0.2])
+    assert not isinstance(binner._bin_centers, u.Quantity)
+    assert not isinstance(binner._bin_widths, u.Quantity)
+
+
+def test_fluxbinner_normalizes_wavelength_quantities():
+    """Wavelength centers and widths use microns internally."""
+    binner = FluxBinner(
+        wlgrid=np.array([2000.0, 1000.0]) * u.nm,
+        wlgrid_width=np.array([200.0, 100.0]) * u.nm,
+    )
+
+    np.testing.assert_allclose(binner._bin_centers, [1.0, 2.0])
+    np.testing.assert_allclose(binner._bin_widths, [0.1, 0.2])
+    assert not isinstance(binner._bin_centers, u.Quantity)
+    assert not isinstance(binner._bin_widths, u.Quantity)
 
 
 def test_native_binner():

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -59,6 +59,36 @@ def test_planet_property_setters_accept_quantity_values():
     assert planet.get_planet_semimajoraxis("AU") == pytest.approx(2.0)
 
 
+def test_planet_normalizes_orbital_quantity_inputs():
+    """Orbital times and dimensionless inputs use their documented units."""
+    planet = Planet(
+        impact_param=50.0 * u.percent,
+        orbital_period=48.0 * u.hour,
+        albedo=30.0 * u.percent,
+        transit_time=50.0 * u.min,
+    )
+
+    assert planet.impactParameter == pytest.approx(0.5)
+    assert planet.orbitalPeriod == pytest.approx(2.0)
+    assert planet.albedo == pytest.approx(0.3)
+    assert planet.transitTime == pytest.approx(3000.0)
+
+
+@pytest.mark.parametrize(
+    ("parameter", "quantity"),
+    [
+        ("impact_param", 1.0 * u.m),
+        ("orbital_period", 1.0 * u.kg),
+        ("albedo", 1.0 * u.Pa),
+        ("transit_time", 1.0 * u.K),
+    ],
+)
+def test_planet_rejects_incompatible_orbital_quantities(parameter, quantity):
+    """Orbital parameters reject quantities with incompatible dimensions."""
+    with pytest.raises(u.UnitConversionError):
+        Planet(**{parameter: quantity})
+
+
 @pytest.mark.parametrize(
     "setter_name",
     ["set_planet_mass", "set_planet_radius", "set_planet_semimajoraxis"],

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -51,9 +51,15 @@ def test_planet_property_setters_accept_quantity_values():
     planet.radius = 3.0 * u.R_earth
     planet.distance = 1.5e6 * u.km
 
-    assert planet.get_planet_mass("kg") == pytest.approx((2.0 * u.M_earth).to_value(u.kg))
-    assert planet.get_planet_radius("m") == pytest.approx((3.0 * u.R_earth).to_value(u.m))
-    assert planet.get_planet_semimajoraxis("m") == pytest.approx((1.5e6 * u.km).to_value(u.m))
+    assert planet.get_planet_mass("kg") == pytest.approx(
+        (2.0 * u.M_earth).to_value(u.kg)
+    )
+    assert planet.get_planet_radius("m") == pytest.approx(
+        (3.0 * u.R_earth).to_value(u.m)
+    )
+    assert planet.get_planet_semimajoraxis("m") == pytest.approx(
+        (1.5e6 * u.km).to_value(u.m)
+    )
 
     planet.semiMajorAxis = 2.0 * u.AU
     assert planet.get_planet_semimajoraxis("AU") == pytest.approx(2.0)

--- a/tests/test_planet.py
+++ b/tests/test_planet.py
@@ -43,6 +43,22 @@ def test_planet_quantity_uses_attached_unit():
     assert planet.get_planet_radius("m") == pytest.approx(1000.0)
 
 
+def test_planet_property_setters_accept_quantity_values():
+    """Public property setters normalize Quantity values at the API boundary."""
+    planet = Planet()
+
+    planet.mass = 2.0 * u.M_earth
+    planet.radius = 3.0 * u.R_earth
+    planet.distance = 1.5e6 * u.km
+
+    assert planet.get_planet_mass("kg") == pytest.approx((2.0 * u.M_earth).to_value(u.kg))
+    assert planet.get_planet_radius("m") == pytest.approx((3.0 * u.R_earth).to_value(u.m))
+    assert planet.get_planet_semimajoraxis("m") == pytest.approx((1.5e6 * u.km).to_value(u.m))
+
+    planet.semiMajorAxis = 2.0 * u.AU
+    assert planet.get_planet_semimajoraxis("AU") == pytest.approx(2.0)
+
+
 @pytest.mark.parametrize(
     "setter_name",
     ["set_planet_mass", "set_planet_radius", "set_planet_semimajoraxis"],

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -216,6 +216,7 @@ def test_convert_to_unit_value_converts_quantity_sequence():
 
     np.testing.assert_allclose(converted, [0.05, 0.01])
     assert not isinstance(converted, u.Quantity)
+    assert not any(isinstance(value, u.Quantity) for value in converted)
 
 
 def test_convert_to_unit_value_supports_equivalencies():

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -204,6 +204,20 @@ def test_convert_to_unit_value_converts_quantity():
     assert not isinstance(converted, u.Quantity)
 
 
+def test_convert_to_unit_value_converts_quantity_sequence():
+    """A list-like sequence of quantities should also normalize to plain values."""
+    import astropy.units as u
+
+    from taurex.util import convert_to_unit_value
+
+    values = [5 * u.percent, 1 * u.percent]
+
+    converted = convert_to_unit_value(values, u.dimensionless_unscaled)
+
+    np.testing.assert_allclose(converted, [0.05, 0.01])
+    assert not isinstance(converted, u.Quantity)
+
+
 def test_convert_to_unit_value_supports_equivalencies():
     """Conversions can use Astropy equivalencies such as spectral units."""
     import astropy.units as u


### PR DESCRIPTION
## Summary

This PR continues the Astropy unit support introduced in PR #159, it is therefore a stacked PR.

After the merge of PR #159 the base of this PR should be changed to `main`.
For now, we choose `33_Astropy_units` as the base, so only the extra commits are shown.

It extends unit-aware physical inputs to chemistry, cloud and Mie
contributions, stellar parameters, spectral grids and binners,
temperature profiles, model pressure inputs, and planetary orbital
parameters.

It also defines a small chemistry-level contract for condensate particle
number-density profiles. This keeps condensate mixing-ratio profiles and
particle number-density profiles separate, avoiding ambiguous implicit
conversion between physically different representations.

## Unit handling

Public physical inputs may be supplied either as legacy plain numeric
values or as `astropy.units.Quantity` values. Quantities are converted at
the public boundary and internal calculations continue to use plain
numeric values in the documented internal units.

Ambiguous heterogeneous inputs, legacy file-driven interfaces, and
low-level numerical kernels remain outside this compatibility layer.
These boundaries are documented explicitly.

## Validation

- `289 passed`
- `git diff --check` passes
- the new physical-units documentation page builds without warnings

## Related issue

Advances #33.
Follows #159.